### PR TITLE
[BE - #220] 테스트 및 개발 기간을 위해 코딩존 수업 예약 기간 조건 제거

### DIFF
--- a/backend/build/resources/main/application.properties
+++ b/backend/build/resources/main/application.properties
@@ -13,6 +13,7 @@ spring.datasource.password=${DATABASE_PASSWORD}
 # Database Redis
 spring.redis.host=${REDIS_URL}
 spring.redis.port=${REDIS_PORT}
+spring.redis.password=${REDIS_PASSWORD}
 
 spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=110MB

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -296,6 +296,7 @@ public class CodingZoneServiceImplement implements CodingZoneService {
     List<CodingZoneClass> classEntities = new ArrayList<>();
         int registedClassNum = 0;
         try {
+            System.out.println("✅ getClassList 진입 완료");
             // 사용자 계정이 존재하는지(로그인 시간이 초과됐는지) 확인하는 코드
             boolean existedUser = userRepository.existsByEmail(email);
             if (!existedUser) return GetListOfCodingZoneClassResponseDto.notExistUser();
@@ -304,19 +305,26 @@ public class CodingZoneServiceImplement implements CodingZoneService {
 
             // 현재 날짜가 수요일에서 일요일 사이인지 확인 (Asia/Seoul 시간대 적용)
             ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-            ZonedDateTime lowerBound;
 
-            // 이번 주 목요일 오후 4시를 lower bound 변수에 저장
-            // 만약 현재가 월~수요일이면, 즉 이번주 목요일 오후 4시가 아직 미래일 때 이번 주 목요일(오후 4시)를 반환 받기
-            if (now.getDayOfWeek().getValue() <= DayOfWeek.WEDNESDAY.getValue()) {
-                lowerBound = now.with(TemporalAdjusters.next(DayOfWeek.THURSDAY))
-                        .withHour(16).withMinute(0).withSecond(0).withNano(0);
-            } else {
-                // 만약 현재가 목요일(오후 4시 이후) 또는 금~일요일인 경우, 즉 이번주 목요일 오후 4시가 과거일 때 이번 주 목요일(오후 4시)를 반환 받기
-                lowerBound = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.THURSDAY))
-                        .withHour(16).withMinute(0).withSecond(0).withNano(0);
-            }
-            // upperBound는 이번 주 일요일의 마지막 순간 (예: 23:59:59.999...)로 설정
+            // 운영을 위한 조건
+            // ZonedDateTime lowerBound;
+            // // 이번 주 목요일 오후 4시를 lower bound 변수에 저장
+            // // 만약 현재가 월~수요일이면, 즉 이번주 목요일 오후 4시가 아직 미래일 때 이번 주 목요일(오후 4시)를 반환 받기
+            // if (now.getDayOfWeek().getValue() <= DayOfWeek.WEDNESDAY.getValue()) {
+            //     lowerBound = now.with(TemporalAdjusters.next(DayOfWeek.THURSDAY))
+            //             .withHour(16).withMinute(0).withSecond(0).withNano(0);
+            // } else {
+            //     // 만약 현재가 목요일(오후 4시 이후) 또는 금~일요일인 경우, 즉 이번주 목요일 오후 4시가 과거일 때 이번 주 목요일(오후 4시)를 반환 받기
+            //     lowerBound = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.THURSDAY))
+            //             .withHour(16).withMinute(0).withSecond(0).withNano(0);
+            // }
+            // // upperBound는 이번 주 일요일의 마지막 순간 (예: 23:59:59.999...)로 설정
+            // ZonedDateTime upperBound = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+            //         .with(LocalTime.MAX);
+
+            // 개발 & 테스트 기간을 위한 조건
+            ZonedDateTime lowerBound = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                    .with(LocalTime.MIN);
             ZonedDateTime upperBound = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
                     .with(LocalTime.MAX);
 
@@ -362,19 +370,26 @@ public class CodingZoneServiceImplement implements CodingZoneService {
 
             // 현재 날짜가 수요일에서 일요일 사이인지 확인 (Asia/Seoul 시간대 적용)
             ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-            ZonedDateTime lowerBound;
 
-            // 이번 주 목요일 오후 4시를 lower bound 변수에 저장
-            // 만약 현재가 월~수요일이면, 즉 이번주 목요일 오후 4시가 아직 미래일 때 이번 주 목요일(오후 4시)를 반환 받기
-            if (now.getDayOfWeek().getValue() <= DayOfWeek.WEDNESDAY.getValue()) {
-                lowerBound = now.with(TemporalAdjusters.next(DayOfWeek.THURSDAY))
-                        .withHour(16).withMinute(0).withSecond(0).withNano(0);
-            } else {
-                // 만약 현재가 목요일(오후 4시 이후) 또는 금~일요일인 경우, 즉 이번주 목요일 오후 4시가 과거일 때 이번 주 목요일(오후 4시)를 반환 받기
-                lowerBound = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.THURSDAY))
-                        .withHour(16).withMinute(0).withSecond(0).withNano(0);
-            }
-            // upperBound는 이번 주 일요일의 마지막 순간 (예: 23:59:59.999...)로 설정
+            // 운영을 위한 조건
+            // ZonedDateTime lowerBound;
+            // // 이번 주 목요일 오후 4시를 lower bound 변수에 저장
+            // // 만약 현재가 월~수요일이면, 즉 이번주 목요일 오후 4시가 아직 미래일 때 이번 주 목요일(오후 4시)를 반환 받기
+            // if (now.getDayOfWeek().getValue() <= DayOfWeek.WEDNESDAY.getValue()) {
+            //     lowerBound = now.with(TemporalAdjusters.next(DayOfWeek.THURSDAY))
+            //             .withHour(16).withMinute(0).withSecond(0).withNano(0);
+            // } else {
+            //     // 만약 현재가 목요일(오후 4시 이후) 또는 금~일요일인 경우, 즉 이번주 목요일 오후 4시가 과거일 때 이번 주 목요일(오후 4시)를 반환 받기
+            //     lowerBound = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.THURSDAY))
+            //             .withHour(16).withMinute(0).withSecond(0).withNano(0);
+            // }
+            // // upperBound는 이번 주 일요일의 마지막 순간 (예: 23:59:59.999...)로 설정
+            // ZonedDateTime upperBound = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+            //         .with(LocalTime.MAX);
+
+            // 개발 & 테스트 기간을 위한 조건
+            ZonedDateTime lowerBound = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                    .with(LocalTime.MIN);
             ZonedDateTime upperBound = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
                     .with(LocalTime.MAX);
 


### PR DESCRIPTION
## 📌 변경 사항
- 다음 주 수업 조회 시 요일 조건(목~금 범위) 제거
- 개발/테스트 환경에서 요일에 관계없이 다음 주 전체 수업 조회 가능하도록 임시 로직 반영

## 🔍 상세 내용
- 기존에는 `목요일 16:00 ~ 금요일 23:59:59` 범위 내에서만 다음 주 수업 조회 가능했음
- 해당 조건을 완화하여 **이번 주 월요일 00:00부터 일요일 23:59:59까지**인 경우에만 조회 가능하도록 수정
- `ZonedDateTime.now()` 기준으로 현재 시각이 해당 범위에 포함되면 다음 주 수업 데이터를 반환
- 운영 배포 시 원래 조건으로 쉽게 복구할 수 있도록 로직 구조 유지

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음