### PR TITLE
[FE - #226] 코딩존 네이게이션 바 모듈화 작업

### DIFF
--- a/frontend/src/pages/Coding-zone/CodingZoneAttendanceAssistant.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneAttendanceAssistant.js
@@ -22,31 +22,7 @@ const CodingZoneAttendanceAssistant = () => {
     const token = cookies.accessToken;
     const navigate = useNavigate();
     const [selectedDate, setSelectedDate] = useState(new Date());
-    const [showModal, setShowModal] = useState(false);
-    const [selectedButton, setSelectedButton] = useState('attendence');
-
-    const handleOpenModal = () => {
-        setShowModal(true);
-    };
-
-    const handleCloseModal = () => {
-        setShowModal(false);
-    };
-
-    const handlecodingzone = () => {
-        setSelectedButton('codingzone');
-        navigate('/coding-zone');
-    };
-
-    const handlecodingzoneattendence = () => {
-        setSelectedButton('attendence');
-        navigate(`/coding-zone/Codingzone_Attendance`);
-    };
-
-    const handleInquiry = () => {
-        setSelectedButton('inquiry');
-    };
-
+    
 
 
     useEffect(() => {
@@ -143,13 +119,7 @@ const CodingZoneAttendanceAssistant = () => {
     return (
         <div>
             <div className="codingzone-container">
-                <CodingZoneNavigation //코딩존 네비게이션바
-                    selectedButton={selectedButton}
-                    handleTabChange={handleTabChange}
-                    handleOpenModal={handleOpenModal}
-                    showModal={showModal}
-                    handleCloseModal={handleCloseModal}
-                />
+                <CodingZoneNavigation/>
                 <div className="banner_img_container">
                     <img src="/codingzone_attendance3.png" className="banner" />
                 </div>
@@ -157,7 +127,7 @@ const CodingZoneAttendanceAssistant = () => {
             <div className="cza_button_container" style={{ textAlign: 'center' }}>
                 <button
                     className={`btn-attend ${activeButton === 'check' ? 'active' : ''}`}
-                    onClick={() => { setActiveButton('check'); handlecodingzoneattendence(); }}
+                    onClick={() => { setActiveButton('check');navigate('/coding-zone/Codingzone_Attendance') }}
                 >
                     출결 확인
                 </button>

--- a/frontend/src/pages/Coding-zone/CodingZoneAttendanceManager.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneAttendanceManager.js
@@ -8,6 +8,7 @@ import '../css/codingzone/codingzone_all_attendance.css';
 import { useNavigate } from 'react-router-dom';
 import InquiryModal from './InquiryModal.js';
 import { getczauthtypetRequest } from '../../shared/api/AuthApi.js';
+import CodingZoneNavigation from '../../shared/ui/navigation/CodingZoneNavigation.js'; //코딩존 네이게이션 바 컴포넌트 
 
 const CodingZoneAttendanceManager = () => {
     const [authMessage, setAuthMessage] = useState('');
@@ -69,7 +70,7 @@ const CodingZoneAttendanceManager = () => {
 
     useEffect(() => {
         const fetchAuthType = async () => {
-            const response = await getczauthtypetRequest(token,setCookie, navigate);
+            const response = await getczauthtypetRequest(token, setCookie, navigate);
             if (response) {
                 switch (response.code) {
                     case "CA":
@@ -102,7 +103,7 @@ const CodingZoneAttendanceManager = () => {
 
     useEffect(() => {
         const fetchAttendanceData = async () => {
-            const response = await getczallattendRequest(token,setCookie, navigate);
+            const response = await getczallattendRequest(token, setCookie, navigate);
             if (response && response.code === "SU") {
                 // Filter data based on selected grade
                 const filteredData = response.studentList.filter(student => student.grade === selectedGrade);
@@ -151,41 +152,20 @@ const CodingZoneAttendanceManager = () => {
             alert("로그인 후 이용 가능합니다.");
             return;
         }
-        await downloadAttendanceExcel(token, selectedGrade,setCookie, navigate);
+        await downloadAttendanceExcel(token, selectedGrade, setCookie, navigate);
     };
 
 
     return (
         <div>
             <div className="codingzone-container">
-                <div className='select-container'>
-                    <span> | </span>
-                    <button
-                        onClick={handlecodingzone}
-                        className={selectedButton === 'codingzone' ? 'selected' : ''}
-                    >
-                        코딩존 예약
-                    </button>
-                    <span> | </span>
-                    <button
-                        onClick={handlecodingzoneattendence}
-                        className={selectedButton === 'attendence' ? 'selected' : ''}
-                    >
-                        출결 관리
-                    </button>
-                    <span> | </span>
-                    <button
-                        onClick={() => {
-                            handleInquiry();
-                            handleOpenModal();
-                        }}
-                        className={selectedButton === 'inquiry' ? 'selected' : ''}
-                    >
-                        문의 하기
-                    </button>
-                    {showModal && <InquiryModal isOpen={showModal} onClose={handleCloseModal} />}
-                    <span> | </span>
-                </div>
+                <CodingZoneNavigation //코딩존 네비게이션바
+                    selectedButton={selectedButton}
+                    handleTabChange={handleTabChange}
+                    handleOpenModal={handleOpenModal}
+                    showModal={showModal}
+                    handleCloseModal={handleCloseModal}
+                />
                 <div className="banner_img_container">
                     <img src="/codingzone_attendance5.png" className="banner" />
                 </div>

--- a/frontend/src/pages/Coding-zone/CodingZoneAttendanceManager.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneAttendanceManager.js
@@ -8,7 +8,8 @@ import '../css/codingzone/codingzone_all_attendance.css';
 import { useNavigate } from 'react-router-dom';
 import InquiryModal from './InquiryModal.js';
 import { getczauthtypetRequest } from '../../shared/api/AuthApi.js';
-import CodingZoneNavigation from '../../shared/ui/navigation/CodingZoneNavigation.js'; //코딩존 네이게이션 바 컴포넌트 
+import CodingZoneNavigation from '../../shared/ui/navigation/CodingZoneNavigation.js'; //코딩존 네이게이션 바 컴포넌트
+
 
 const CodingZoneAttendanceManager = () => {
     const [authMessage, setAuthMessage] = useState('');
@@ -21,51 +22,17 @@ const CodingZoneAttendanceManager = () => {
     const [selectedGrade, setSelectedGrade] = useState(1);
     const token = cookies.accessToken;
     const navigate = useNavigate();
-    const [showModal, setShowModal] = useState(false);
     const [selectedButton, setSelectedButton] = useState('attendence');
-
-    const handleOpenModal = () => {
-        setShowModal(true);
-    };
-
-    const handleCloseModal = () => {
-        setShowModal(false);
-    };
 
 
     const handlecodingzonemanager = () => {
         navigate(`/coding-zone/Codingzone_Manager`);
     };
 
-    const handleFullManagement = () => {
-        navigate(`/coding-zone/Codingzone_All_Attend`);
-    };
 
     const handleClassRegistration = () => {
         navigate(`/coding-zone/coding-class-regist`);
     };
-
-
-    const handlecodingzone = () => {
-        setSelectedButton('codingzone');
-        navigate('/coding-zone');
-    };
-
-    const handlecodingzoneattendence = () => {
-
-        const token = cookies.accessToken;
-        if (!token) {
-            alert("로그인 후 이용 가능합니다.");
-            return;
-        }
-        setSelectedButton('attendence');
-        navigate(`/coding-zone/Codingzone_Attendance`);
-    };
-
-    const handleInquiry = () => {
-        setSelectedButton('attendence');
-    };
-
 
 
     useEffect(() => {
@@ -159,13 +126,8 @@ const CodingZoneAttendanceManager = () => {
     return (
         <div>
             <div className="codingzone-container">
-                <CodingZoneNavigation //코딩존 네비게이션바
-                    selectedButton={selectedButton}
-                    handleTabChange={handleTabChange}
-                    handleOpenModal={handleOpenModal}
-                    showModal={showModal}
-                    handleCloseModal={handleCloseModal}
-                />
+                <CodingZoneNavigation />
+
                 <div className="banner_img_container">
                     <img src="/codingzone_attendance5.png" className="banner" />
                 </div>
@@ -173,7 +135,7 @@ const CodingZoneAttendanceManager = () => {
             <div className="cza_button_container" style={{ textAlign: 'center' }}>
                 <button
                     className={`btn-attend ${activeButton === 'check' ? 'active' : ''}`}
-                    onClick={() => { setActiveButton('check'); handlecodingzoneattendence(); }}
+                    onClick={() => { setActiveButton('check'); navigate(`/coding-zone/Codingzone_Attendance`); }}
                 >
                     출결 확인
                 </button>

--- a/frontend/src/pages/Coding-zone/CodingZoneMain.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneMain.js
@@ -53,7 +53,7 @@ const CodingMain = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [selectedZone, setSelectedZone] = useState(1);
-  const [selectedButton, setSelectedButton] = useState('codingzone');
+
   const [userReservedClass, setUserReservedClass] = useState(null);
   const [selectedDay, setSelectedDay] = useState('');
   const [isRendered, setIsRendered] = useState(false);
@@ -151,14 +151,6 @@ const CodingMain = () => {
       setSelectedDay(day);
     }
   };
-
-  useEffect(() => {
-    if (location.pathname === '/coding-zone') {
-      setSelectedButton('codingzone');
-    } else if (location.pathname.includes('/coding-zone/Codingzone_Attendance')) {
-      setSelectedButton('attendence');
-    }
-  }, [location.pathname]);
 
   const token = cookies.accessToken;
   /// 코딩존 수업 데이터를 가져오는 useEffect
@@ -264,18 +256,7 @@ const CodingMain = () => {
 
 
 
-  const handleTabChange = (tab) => {
-    if (tab === 'attendence' && !cookies.accessToken) {
-      alert("로그인 후 이용 가능합니다.");
-      return;
-    }
-    setSelectedButton(tab);
-    if (tab === 'codingzone') {
-      navigate('/coding-zone');
-    } else if (tab === 'attendence') {
-      navigate('/coding-zone/Codingzone_Attendance');
-    }
-  };
+
 
 
   const handleCardClick = (classItem) => {
@@ -286,16 +267,6 @@ const CodingMain = () => {
       item.classNum === classNum ? { ...item, isReserved, currentNumber: newCurrentNumber } : item
     );
     setClassList(updatedList);
-  };
-
-  const [showModal, setShowModal] = useState(false);
-
-  const handleOpenModal = () => {
-    setShowModal(true);
-  };
-
-  const handleCloseModal = () => {
-    setShowModal(false);
   };
 
   const sliderSettings = {
@@ -332,15 +303,7 @@ const CodingMain = () => {
 
   return (
     <div className="codingzone-container">
-
-      <CodingZoneNavigation //코딩존 네비게이션바
-        selectedButton={selectedButton}
-        handleTabChange={handleTabChange}
-        handleOpenModal={handleOpenModal}
-        showModal={showModal}
-        handleCloseModal={handleCloseModal}
-      />
-
+      <CodingZoneNavigation />
       <Slider {...sliderSettings}>
         <div className="codingzone-top-container">
           <picture>

--- a/frontend/src/pages/Coding-zone/CodingZoneMain.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneMain.js
@@ -12,6 +12,8 @@ import "slick-carousel/slick/slick-theme.css";
 import Slider from 'react-slick';
 import { getAttendanceCount, getcodingzoneListRequest } from '../../features/api/CodingzoneApi.js';
 import { deleteCodingZoneClass, reserveCodingZoneClass } from '../../entities/api/CodingZone/StudentApi.js';
+
+import CodingZoneNavigation from '../../shared/ui/navigation/CodingZoneNavigation.js'; //코딩존 네이게이션 바 컴포넌트
 const ClassList = ({ userReservedClass, onDeleteClick, classList, handleCardClick, handleToggleReservation, isAdmin }) => {
   return (
     <div className='cz-card'>
@@ -330,31 +332,14 @@ const CodingMain = () => {
 
   return (
     <div className="codingzone-container">
-      <div className='select-container'>
-        <span> | </span>
-        <button
-          onClick={() => handleTabChange('codingzone')}
-          className={selectedButton === 'codingzone' ? 'selected' : ''}
-        >
-          코딩존 예약
-        </button>
-        <span> | </span>
-        <button
-          onClick={() => handleTabChange('attendence')}
-          className={selectedButton === 'attendence' ? 'selected' : ''}
-        >
-          출결 관리
-        </button>
-        <span> | </span>
-        <button
-          onClick={handleOpenModal}
-          className={selectedButton === 'inquiry' ? 'selected' : ''}
-        >
-          문의 하기
-        </button>
-        {showModal && <InquiryModal isOpen={showModal} onClose={handleCloseModal} />}
-        <span> | </span>
-      </div>
+
+      <CodingZoneNavigation //코딩존 네비게이션바
+        selectedButton={selectedButton}
+        handleTabChange={handleTabChange}
+        handleOpenModal={handleOpenModal}
+        showModal={showModal}
+        handleCloseModal={handleCloseModal}
+      />
 
       <Slider {...sliderSettings}>
         <div className="codingzone-top-container">
@@ -435,33 +420,33 @@ const CodingMain = () => {
           </div>
         </div>
         <div className="codingzone-list">
-  {/* 항상 렌더되도록 유지하고, show/hide는 CSS 클래스 이름으로 제어 */}
-  <picture className={`no-classes-image ${showNoClassesImage ? 'visible' : 'hidden'}`}>
-    <source srcSet="/Codingzone-noregist.webp" type="image/webp" />
-    <img
-      src="/Codingzone-noregist.png"
-      alt="수업이 없습니다"
-      className="no-classes-img"
-      width="600"
-      height="260"
-      loading="eager"
-      decoding="sync"
-    />
-  </picture>
+          {/* 항상 렌더되도록 유지하고, show/hide는 CSS 클래스 이름으로 제어 */}
+          <picture className={`no-classes-image ${showNoClassesImage ? 'visible' : 'hidden'}`}>
+            <source srcSet="/Codingzone-noregist.webp" type="image/webp" />
+            <img
+              src="/Codingzone-noregist.png"
+              alt="수업이 없습니다"
+              className="no-classes-img"
+              width="600"
+              height="260"
+              loading="eager"
+              decoding="sync"
+            />
+          </picture>
 
-  {/* 수업이 있을 경우에만 ClassList 보여줌 */}
-  {!showNoClassesImage && (
-    <ClassList
-      classList={classList}
-      handleCardClick={handleCardClick}
-      handleToggleReservation={handleToggleReservation}
-      isAdmin={isAdmin}
-      onDeleteClick={handleDelete}
-      userReservedClass={userReservedClass}
-      token={token}
-    />
-  )}
-</div>
+          {/* 수업이 있을 경우에만 ClassList 보여줌 */}
+          {!showNoClassesImage && (
+            <ClassList
+              classList={classList}
+              handleCardClick={handleCardClick}
+              handleToggleReservation={handleToggleReservation}
+              isAdmin={isAdmin}
+              onDeleteClick={handleDelete}
+              userReservedClass={userReservedClass}
+              token={token}
+            />
+          )}
+        </div>
 
 
       </div>

--- a/frontend/src/pages/Coding-zone/CodingZoneMyAttendance.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneMyAttendance.js
@@ -18,38 +18,7 @@ const CodingZoneMyAttendance = () => {
     const [cookies, setCookie] = useCookies(['accessToken']);
     const [activeButton, setActiveButton] = useState('check');
     const token = cookies.accessToken;
-    const [selectedButton, setSelectedButton] = useState('attendence');
     const navigate = useNavigate();
-    const [showModal, setShowModal] = useState(false);
-
-    const handleOpenModal = () => {
-        setShowModal(true);
-    };
-
-    const handleCloseModal = () => {
-        setShowModal(false);
-    };
-    const handlecodingzone = () => {
-        setSelectedButton('codingzone');
-        navigate('/coding-zone');
-    };
-
-    const handlecodingzoneattendence = () => {
-
-        const token = cookies.accessToken;
-        if (!token) {
-            alert("로그인 후 이용 가능합니다.");
-            return;
-        }
-        setSelectedButton('attendence');
-        navigate(`/coding-zone/Codingzone_Attendance`);
-    };
-
-    const handleInquiry = () => {
-        setSelectedButton('attendence');
-    };
-
-
 
     const handlecodingzonemanager = () => {
         navigate(`/coding-zone/Codingzone_Manager`);
@@ -130,13 +99,7 @@ const CodingZoneMyAttendance = () => {
     return (
         <div>
             <div className="codingzone-container">
-                <CodingZoneNavigation //코딩존 네비게이션바
-                    selectedButton={selectedButton}
-                    handleTabChange={handleTabChange}
-                    handleOpenModal={handleOpenModal}
-                    showModal={showModal}
-                    handleCloseModal={handleCloseModal}
-                />
+               <CodingZoneNavigation/>
 
                 <div className="banner_img_container">
                     <img src="/codingzone_attendance2.png" className="banner" />

--- a/frontend/src/pages/Coding-zone/CodingZoneMyAttendance.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneMyAttendance.js
@@ -7,6 +7,8 @@ import '../css/codingzone/codingzone_attend.css';
 import { useNavigate, useLocation } from 'react-router-dom';
 import InquiryModal from './InquiryModal.js';
 import { getczattendlistRequest } from '../../features/api/CodingzoneApi.js';
+import CodingZoneNavigation from '../../shared/ui/navigation/CodingZoneNavigation.js'; //코딩존 네이게이션 바 컴포넌트
+
 const CodingZoneMyAttendance = () => {
     const [authMessage, setAuthMessage] = useState('');
     const [attendList, setAttendList] = useState([]);
@@ -16,7 +18,7 @@ const CodingZoneMyAttendance = () => {
     const [cookies, setCookie] = useCookies(['accessToken']);
     const [activeButton, setActiveButton] = useState('check');
     const token = cookies.accessToken;
-    const [selectedButton, setSelectedButton] = useState('attendence'); 
+    const [selectedButton, setSelectedButton] = useState('attendence');
     const navigate = useNavigate();
     const [showModal, setShowModal] = useState(false);
 
@@ -33,15 +35,15 @@ const CodingZoneMyAttendance = () => {
     };
 
     const handlecodingzoneattendence = () => {
-   
+
         const token = cookies.accessToken;
         if (!token) {
-          alert("로그인 후 이용 가능합니다.");
-          return; 
+            alert("로그인 후 이용 가능합니다.");
+            return;
         }
         setSelectedButton('attendence');
         navigate(`/coding-zone/Codingzone_Attendance`);
-      };
+    };
 
     const handleInquiry = () => {
         setSelectedButton('attendence');
@@ -81,7 +83,7 @@ const CodingZoneMyAttendance = () => {
 
     useEffect(() => {
         const fetchAuthType = async () => {
-            const response = await getczauthtypetRequest(token,setCookie, navigate);
+            const response = await getczauthtypetRequest(token, setCookie, navigate);
             if (response) {
                 switch (response.code) {
                     case "CA":
@@ -111,7 +113,7 @@ const CodingZoneMyAttendance = () => {
 
     useEffect(() => {
         const fetchAttendList = async () => {
-            const response = await getczattendlistRequest(token,setCookie, navigate);
+            const response = await getczattendlistRequest(token, setCookie, navigate);
             if (response && response.code === "SU") {
                 setAttendList(response.attendList);
             } else if (response && response.code === "NU") {
@@ -128,34 +130,14 @@ const CodingZoneMyAttendance = () => {
     return (
         <div>
             <div className="codingzone-container">
-                <div className='select-container'>
-                    <span> | </span>
-                    <button
-                        onClick={handlecodingzone}
-                        className={selectedButton === 'codingzone' ? 'selected' : ''}
-                    >
-                        코딩존 예약
-                    </button>
-                    <span> | </span>
-                    <button
-                        onClick={handlecodingzoneattendence}
-                        className={selectedButton === 'attendence' ? 'selected' : ''}
-                    >
-                        출결 관리
-                    </button>
-                    <span> | </span>
-                    <button
-                        onClick={() => {
-                            handleInquiry();
-                            handleOpenModal();
-                        }}
-                        className={selectedButton === 'inquiry' ? 'selected' : ''}
-                    >
-                        문의 하기
-                    </button>
-                    {showModal && <InquiryModal isOpen={showModal} onClose={handleCloseModal} />}
-                    <span> | </span>
-                </div>
+                <CodingZoneNavigation //코딩존 네비게이션바
+                    selectedButton={selectedButton}
+                    handleTabChange={handleTabChange}
+                    handleOpenModal={handleOpenModal}
+                    showModal={showModal}
+                    handleCloseModal={handleCloseModal}
+                />
+
                 <div className="banner_img_container">
                     <img src="/codingzone_attendance2.png" className="banner" />
                 </div>

--- a/frontend/src/pages/Coding-zone/CodingZoneRegist.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneRegist.js
@@ -22,36 +22,6 @@ const CodingZoneRegist = () => {
     const token = cookies.accessToken;
     const [activeButton, setActiveButton] = useState('manage_class');
     const navigate = useNavigate();
-    const [showModal, setShowModal] = useState(false);
-    const [selectedButton, setSelectedButton] = useState('attendence');
-
-    const handleOpenModal = () => {
-        setShowModal(true);
-    };
-
-    const handleCloseModal = () => {
-        setShowModal(false);
-    };
-
-    const handlecodingzone = () => {
-        setSelectedButton('codingzone');
-        navigate('/coding-zone');
-    };
-
-    const handlecodingzoneattendence = () => {
-
-        const token = cookies.accessToken;
-        if (!token) {
-            alert("로그인 후 이용 가능합니다.");
-            return;
-        }
-        setSelectedButton('attendence');
-        navigate(`/coding-zone/Codingzone_Attendance`);
-    };
-
-    const handleInquiry = () => {
-        setSelectedButton('attendence');
-    };
 
     const handlecodingzonemanager = () => {
         navigate(`/coding-zone/Codingzone_Manager`);
@@ -498,13 +468,7 @@ const CodingZoneRegist = () => {
     return (
         <div className="class-regist-main-container">
             <div className="codingzone-container">
-                <CodingZoneNavigation //코딩존 네비게이션바
-                    selectedButton={selectedButton}
-                    handleTabChange={handleTabChange}
-                    handleOpenModal={handleOpenModal}
-                    showModal={showModal}
-                    handleCloseModal={handleCloseModal}
-                />
+                <CodingZoneNavigation/>
 
                 <div className="banner_img_container">
                     <img src="/codingzone_attendance4.png" className="banner" />
@@ -513,7 +477,7 @@ const CodingZoneRegist = () => {
                     <div className="cza_button_container" style={{ textAlign: 'center' }}>
                         <button
                             className={`btn-attend ${activeButton === 'check' ? 'active' : ''}`}
-                            onClick={() => { setActiveButton('check'); handlecodingzoneattendence(); }}
+                            onClick={() => { setActiveButton('check'); navigate(`/coding-zone/Codingzone_Attendance`); }}
                         >
                             출결 확인
                         </button>

--- a/frontend/src/pages/Coding-zone/CodingZoneRegist.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneRegist.js
@@ -5,9 +5,9 @@ import { useCookies } from "react-cookie";
 import InquiryModal from './InquiryModal';
 import '../css/codingzone/codingzone-main.css';
 import { resetCodingZoneData } from '../../features/api/Admin/Codingzone/ClassApi';
-import { uploadGroupData, fetchGroupClasses,uploadClassForWeek } from '../../entities/api/CodingZone/AdminApi';
+import { uploadGroupData, fetchGroupClasses, uploadClassForWeek } from '../../entities/api/CodingZone/AdminApi';
 import { getczauthtypetRequest } from '../../shared/api/AuthApi';
-
+import CodingZoneNavigation from '../../shared/ui/navigation/CodingZoneNavigation.js'; //코딩존 네이게이션 바 컴포넌트
 
 const CodingZoneRegist = () => {
     const [boxes, setBoxes] = useState([{ day: '', time: '', assistant: '', className: '', grade: '', maxPers: '' }]);
@@ -39,15 +39,15 @@ const CodingZoneRegist = () => {
     };
 
     const handlecodingzoneattendence = () => {
-   
+
         const token = cookies.accessToken;
         if (!token) {
-          alert("로그인 후 이용 가능합니다.");
-          return; 
+            alert("로그인 후 이용 가능합니다.");
+            return;
         }
         setSelectedButton('attendence');
         navigate(`/coding-zone/Codingzone_Attendance`);
-      };
+    };
 
     const handleInquiry = () => {
         setSelectedButton('attendence');
@@ -70,7 +70,7 @@ const CodingZoneRegist = () => {
 
     useEffect(() => {
         const fetchAuthType = async () => {
-            const response = await getczauthtypetRequest(token,setCookie, navigate);
+            const response = await getczauthtypetRequest(token, setCookie, navigate);
             if (response) {
                 switch (response.code) {
                     case "CA":
@@ -261,7 +261,7 @@ const CodingZoneRegist = () => {
             weekDay: box.day,
             grade: parseInt(box.grade)
         }));
-        const response = await uploadGroupData(formattedData, cookies.accessToken,setCookie, navigate);
+        const response = await uploadGroupData(formattedData, cookies.accessToken, setCookie, navigate);
         handleGroupUploadResponse(response);
     };
 
@@ -302,7 +302,7 @@ const CodingZoneRegist = () => {
                 grade: parseInt(box.grade)
             };
         });
-        const response = await uploadClassForWeek(formattedData, cookies.accessToken,setCookie, navigate);
+        const response = await uploadClassForWeek(formattedData, cookies.accessToken, setCookie, navigate);
         handleuploadClassForWeekResponse(response);
     };
 
@@ -498,34 +498,14 @@ const CodingZoneRegist = () => {
     return (
         <div className="class-regist-main-container">
             <div className="codingzone-container">
-                <div className='select-container'>
-                    <span> | </span>
-                    <button
-                        onClick={handlecodingzone}
-                        className={selectedButton === 'codingzone' ? 'selected' : ''}
-                    >
-                        코딩존 예약
-                    </button>
-                    <span> | </span>
-                    <button
-                        onClick={handlecodingzoneattendence}
-                        className={selectedButton === 'attendence' ? 'selected' : ''}
-                    >
-                        출결 관리
-                    </button>
-                    <span> | </span>
-                    <button
-                        onClick={() => {
-                            handleInquiry();
-                            handleOpenModal();
-                        }}
-                        className={selectedButton === 'inquiry' ? 'selected' : ''}
-                    >
-                        문의 하기
-                    </button>
-                    {showModal && <InquiryModal isOpen={showModal} onClose={handleCloseModal} />}
-                    <span> | </span>
-                </div>
+                <CodingZoneNavigation //코딩존 네비게이션바
+                    selectedButton={selectedButton}
+                    handleTabChange={handleTabChange}
+                    handleOpenModal={handleOpenModal}
+                    showModal={showModal}
+                    handleCloseModal={handleCloseModal}
+                />
+
                 <div className="banner_img_container">
                     <img src="/codingzone_attendance4.png" className="banner" />
                 </div>

--- a/frontend/src/shared/ui/navigation/CodingZoneNavigation.css
+++ b/frontend/src/shared/ui/navigation/CodingZoneNavigation.css
@@ -1,0 +1,81 @@
+.cz-nav-wrapper { 
+  padding: 10px 20px;
+  display: flex;
+  justify-content: center;
+  max-width: 800px;
+  margin: 20px auto;
+}
+
+.cz-nav-container {
+  display: flex;
+  gap: 60px;
+  align-items: center;
+  flex-wrap: wrap; /* 작은 화면에서는 버튼들이 자동으로 줄바꿈 */
+}
+
+.cz-nav-button {
+  background-color: transparent;
+  border: none;
+  font-size: 16px;
+  color: #002D56;
+  padding: 10px 20px;
+  border-radius: 9999px;
+  font-weight: 400;
+  transition: all 0.3s ease;
+  flex: 1 1 auto; /* 버튼이 작은 화면에서 자연스럽게 크기 조절됨 */
+  text-align: center;
+}
+
+.cz-nav-button:hover {
+  cursor: pointer;
+  background-color: #e1e7ec;
+}
+
+.cz-nav-button.selected {
+  background-color: #002D56;
+  color: white;
+}
+
+/* 📱 모바일 대응 */
+@media (max-width: 600px) {
+  .cz-nav-wrapper {
+    max-width: 100%;
+    padding: 8px 10px;
+  }
+
+  .cz-nav-container {
+    gap: 10px;
+  }
+
+  .cz-nav-button {
+    font-size: 14px;
+    padding: 8px 12px;
+  }
+}
+
+/* 📱 작은 태블릿 대응 */
+@media (max-width: 768px) {
+  .cz-nav-container {
+    gap: 20px;
+  }
+
+  .cz-nav-button {
+    font-size: 15px;
+    padding: 8px 14px;
+  }
+}
+
+/* 💻 데스크톱 대응 */
+@media (min-width: 1024px) {
+  .cz-nav-wrapper {
+    max-width: 900px;
+  }
+
+  .cz-nav-container {
+    gap: 80px;
+  }
+
+  .cz-nav-button {
+    font-size: 16px;
+  }
+}

--- a/frontend/src/shared/ui/navigation/CodingZoneNavigation.js
+++ b/frontend/src/shared/ui/navigation/CodingZoneNavigation.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import InquiryModal from '../../../pages/Coding-zone/InquiryModal'; // 경로는 실제 구조에 따라 조정
+import '../../../pages/css/codingzone/codingzone-main.css'
+
+const CodingZoneNavigation = ({
+  selectedButton,
+  handleTabChange,
+  handleOpenModal,
+  showModal,
+  handleCloseModal
+}) => {
+  return (
+    <div className='select-container'>
+      <span> | </span>
+      <button
+        onClick={() => handleTabChange('codingzone')}
+        className={selectedButton === 'codingzone' ? 'selected' : ''}
+      >
+        코딩존 예약
+      </button>
+      <span> | </span>
+      <button
+        onClick={() => handleTabChange('attendence')}
+        className={selectedButton === 'attendence' ? 'selected' : ''}
+      >
+        출결 관리
+      </button>
+      <span> | </span>
+      <button
+        onClick={handleOpenModal}
+        className={selectedButton === 'inquiry' ? 'selected' : ''}
+      >
+        문의 하기
+      </button>
+      {showModal && <InquiryModal isOpen={showModal} onClose={handleCloseModal} />}
+      <span> | </span>
+    </div>
+  );
+};
+
+export default CodingZoneNavigation;

--- a/frontend/src/shared/ui/navigation/CodingZoneNavigation.js
+++ b/frontend/src/shared/ui/navigation/CodingZoneNavigation.js
@@ -1,14 +1,45 @@
-import React from 'react';
 import InquiryModal from '../../../pages/Coding-zone/InquiryModal'; // 경로는 실제 구조에 따라 조정
 import '../../../pages/css/codingzone/codingzone-main.css'
+import { useLocation, useNavigate } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
 
-const CodingZoneNavigation = ({
-  selectedButton,
-  handleTabChange,
-  handleOpenModal,
-  showModal,
-  handleCloseModal
-}) => {
+const CodingZoneNavigation = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [selectedButton, setSelectedButton] = useState('codingzone');
+  const [showModal, setShowModal] = useState(false);
+
+  useEffect(() => {
+    if (location.pathname === '/coding-zone') {
+      setSelectedButton('codingzone');
+    } else if (location.pathname.includes('/coding-zone/Codingzone_Attendance')) {
+      setSelectedButton('attendence');
+    }
+  }, [location.pathname]);
+
+  const handleTabChange = (tab) => {
+    if (tab === 'attendence' && !document.cookie.includes('accessToken')) {
+      alert('로그인 후 이용 가능합니다.');
+      return;
+    }
+    setSelectedButton(tab);
+    if (tab === 'codingzone') {
+      navigate('/coding-zone');
+    } else if (tab === 'attendence') {
+      navigate('/coding-zone/Codingzone_Attendance');
+    }
+  };
+
+  const handleOpenModal = () => {
+    setSelectedButton('inquiry');
+    setShowModal(true);
+  };
+
+  const handleCloseModal = () => {
+    setShowModal(false);
+  };
+
   return (
     <div className='select-container'>
       <span> | </span>


### PR DESCRIPTION
## 📌 변경 사항
- 네비게이션 바(코딩존 예약, 출결 관리, 문의 사항)를 전역 컴포넌트로 모듈화
- 각 페이지에서 중복되던 네비게이션 UI 제거 및 공통 컴포넌트로 통합
- 반응형 디자인 적용 및 선택 상태 관리 로직 개선

## 🔍 상세 내용
- shared/ui 경로에 공통 네비게이션 컴포넌트 추가

1. shared/ui/Navigation 폴더 생성

2. NavigationWrapper, NavigationButton 컴포넌트 분리

3. 상태 관리 및 선택 로직을 내부에서 처리

- CSS 모듈화 (Navigation.module.css)

1. cz-nav-wrapper, cz-nav-container, cz-nav-button 스타일 관리

2. 반응형 UI를 위한 @media query 적용

3. 각 페이지에서 중복된 네비게이션 UI 코드 제거 후, shared/ui/Navigation 컴포넌트만 import하여 사용

## ✅ 체크리스트
- [X] 기능이 정상적으로 동작하는지 확인했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- shared/ui/Navigation 구조와 컴포넌트 분리 방식이 적절한지 검토 부탁드립니다.
- 반응형 CSS(@media query) 설계가 적절한지 피드백 부탁드립니다.
- 선택 상태 관리 로직(selected 클래스) 개선 가능 여부 검토 부탁드립니다.

## 📎 참고 자료 (선택)
<img width="2076" height="968" alt="image" src="https://github.com/user-attachments/assets/85b6dd94-782c-4162-8e75-0f5c7fc8ce21" />


