### PR TITLE
[BE-#233] 교과목에 해당하는 조교 리스트를 반환하는 비지니스 로직 추가

### DIFF
--- a/backend/src/main/java/com/icehufs/icebreaker/common/ResponseCode.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/common/ResponseCode.java
@@ -17,6 +17,8 @@ public interface ResponseCode {
     String NOT_RESERVE_CLASS = "NR";
     String NOT_SIGNUP_USER = "NS";
     String PERMITTED_ERROR = "PE";
+    String TUTOR_NOT_FOUND = "TNF";
+    String INVALID_SUBJECT_ID = "ISI";
 
     //HTTP Status 401
     String SIGN_IN_FAIL = "SF";

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
@@ -1,6 +1,7 @@
 package com.icehufs.icebreaker.domain.auth.controller;
 
 import com.icehufs.icebreaker.domain.codingzone.dto.response.*;
+import com.icehufs.icebreaker.util.ResponseDto;
 import jakarta.validation.Valid;
 
 import org.springframework.core.io.ByteArrayResource;
@@ -94,6 +95,15 @@ public class EntireAdminController {
         ResponseEntity<? super DeleteAllInfResponseDto> response = codingzoneService.deleteAll(email);
         return response;
     }
+
+    @GetMapping("/subjects/{subjectId}/assistants")
+    public ResponseEntity<ResponseDto<AssistantNamesResponseDto>> getAssistantsBySubject(
+            @PathVariable Long subjectId
+    ) {
+        AssistantNamesResponseDto assistantList = codingzoneService.getAssistantNamesBySubjectId(subjectId);
+        return ResponseEntity.ok(ResponseDto.success("특정 교과목에 해당하는 조교 리스트 조회 성공.", assistantList));
+    }
+
 
     @GetMapping("/excel/attendance/grade1")
     public ResponseEntity<?> downloadArticleExcel() {

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/dto/response/AssistantNamesResponseDto.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/dto/response/AssistantNamesResponseDto.java
@@ -1,0 +1,5 @@
+package com.icehufs.icebreaker.domain.codingzone.dto.response;
+
+import java.util.List;
+
+public record AssistantNamesResponseDto(List<String> assistantNames) {}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
@@ -33,7 +33,7 @@ public interface CodingZoneService {
     ResponseEntity<? super GetPersAttendListItemResponseDto> getPerAttendList(String email);
     ResponseEntity<? super GetReservedClassListItemResponseDto> getReservedClass(String classDate, String email);
     ResponseEntity<? super GetCodingZoneAssitantListResponseDto> getAssistantList();
-
+    AssistantNamesResponseDto getAssistantNamesBySubjectId(Long subjectId);
     //수업 코딩존 조교 
     ResponseEntity<? super PutAttendanceResponseDto> putAttend(Integer registNum, String email);
 


### PR DESCRIPTION
## 📌 변경 사항
교과목에 해당하는 조교 리스트를 반환하는 비지니스 로직을 추가했습니다.

## 🔍 상세 내용

### 과목의 subjectId가 없는 경우
- subjectId가 4 초과일 시에 예외처리 필요해서 추가했습니다.

```json
{
    "code" : "ISI",
    "message" : "유효하지 않은 과목 ID 입니다."
}
```


## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.

Close #233  