### PR TITLE
[BE-#255] 특정 날짜, 특정 교과목으로 등록한 코딩존 수업 정보 리스트 반환 비지니스 로직 작성

### DIFF
--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
@@ -103,14 +103,6 @@ public class EntireAdminController {
         return ResponseEntity.ok(ResponseDto.success("특정 날짜에 이루어진 코딩존 교과목 리스트 조회 성공.", classNames));
     }
 
-    @GetMapping("/subjects/{subjectId}/codingzones")
-    public ResponseEntity<ResponseDto<List<CodingZoneClassInfoResponseDto>>> getCodingZoneClassesBySubjectAndDate(
-        @PathVariable Long subjectId,
-        @RequestParam("date") String date) {
-        List<CodingZoneClassInfoResponseDto> result = codingzoneService.findCodingZoneClassesBySubjectAndDate(subjectId, date);
-        return ResponseEntity.ok(ResponseDto.success("특정 날짜와 교과목에 해당하는 코딩존 수업 리스트 조회 성공.", result));
-    }
-
     @GetMapping("/excel/attendance/grade1")
     public ResponseEntity<?> downloadArticleExcel() {
         try {

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
@@ -103,6 +103,14 @@ public class EntireAdminController {
         return ResponseEntity.ok(ResponseDto.success("특정 날짜에 이루어진 코딩존 교과목 리스트 조회 성공.", classNames));
     }
 
+    @GetMapping("/subjects/{subjectId}/codingzones")
+    public ResponseEntity<ResponseDto<List<CodingZoneClassInfoResponseDto>>> getCodingZoneClassesBySubjectAndDate(
+        @PathVariable Long subjectId,
+        @RequestParam("date") String date) {
+        List<CodingZoneClassInfoResponseDto> result = codingzoneService.findCodingZoneClassesBySubjectAndDate(subjectId, date);
+        return ResponseEntity.ok(ResponseDto.success("특정 날짜와 교과목에 해당하는 코딩존 수업 리스트 조회 성공.", result));
+    }
+
     @GetMapping("/excel/attendance/grade1")
     public ResponseEntity<?> downloadArticleExcel() {
         try {

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/SubjectController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/SubjectController.java
@@ -6,7 +6,6 @@ import com.icehufs.icebreaker.domain.codingzone.dto.response.CodingZoneClassInfo
 import com.icehufs.icebreaker.domain.codingzone.service.CodingZoneService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
 import com.icehufs.icebreaker.common.ResponseMessage;
 import com.icehufs.icebreaker.domain.codingzone.dto.request.PostSubjectMappingRequestDto;
@@ -15,6 +14,13 @@ import com.icehufs.icebreaker.util.ResponseDto;
 import com.icehufs.icebreaker.util.SubjectResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RestController
 @RequestMapping("/api/admin/subjects") // 코딩존 메핑 관련 controller

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/SubjectController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/SubjectController.java
@@ -1,12 +1,12 @@
 package com.icehufs.icebreaker.domain.auth.controller;
 
 import java.util.List;
+
+import com.icehufs.icebreaker.domain.codingzone.dto.response.CodingZoneClassInfoResponseDto;
+import com.icehufs.icebreaker.domain.codingzone.service.CodingZoneService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.icehufs.icebreaker.common.ResponseMessage;
 import com.icehufs.icebreaker.domain.codingzone.dto.request.PostSubjectMappingRequestDto;
@@ -15,7 +15,6 @@ import com.icehufs.icebreaker.util.ResponseDto;
 import com.icehufs.icebreaker.util.SubjectResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
 
 @RestController
 @RequestMapping("/api/admin/subjects") // 코딩존 메핑 관련 controller
@@ -23,6 +22,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class SubjectController {
 
     private final SubjectService subjectService;
+    private final CodingZoneService codingzoneService;
 
     // 코딩존 매핑 등록 controller
     @PostMapping("")
@@ -40,5 +40,13 @@ public class SubjectController {
             @AuthenticationPrincipal String email) {
         return ResponseEntity
                 .ok(ResponseDto.success(ResponseMessage.SUCCESS_CLASS_CREATE, subjectService.getMappingCodingZoneClass(email)));
+    }
+
+    @GetMapping("/{subjectId}/codingzones")
+    public ResponseEntity<ResponseDto<List<CodingZoneClassInfoResponseDto>>> getCodingZoneClassesBySubjectAndDate(
+            @PathVariable Long subjectId,
+            @RequestParam("date") String date) {
+        List<CodingZoneClassInfoResponseDto> result = codingzoneService.findCodingZoneClassesBySubjectAndDate(subjectId, date);
+        return ResponseEntity.ok(ResponseDto.success("특정 날짜와 교과목에 해당하는 코딩존 수업 리스트 조회 성공.", result));
     }
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/domain/entity/CodingZoneClass.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/domain/entity/CodingZoneClass.java
@@ -1,6 +1,8 @@
 package com.icehufs.icebreaker.domain.codingzone.domain.entity;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 import jakarta.persistence.*;
 import org.springframework.http.HttpStatus;
@@ -81,5 +83,23 @@ public class CodingZoneClass {
         DayOfWeek day = date.getDayOfWeek();
         if ((day == DayOfWeek.SATURDAY || day == DayOfWeek.SUNDAY))
             throw new BusinessException(ResponseCode.NOT_WEEKDAY, ResponseMessage.NOT_WEEKDAY, HttpStatus.BAD_REQUEST);
+    }
+
+    public String calculateClassStatus(String date) {
+        LocalDate classDate = LocalDate.parse(date); // "yyyy-MM-dd"
+        LocalTime startTime = LocalTime.parse(classTime); // "HH:mm:ss"
+
+        LocalDateTime startDateTime  = LocalDateTime.of(classDate, startTime);
+        LocalDateTime endDateTime  = startDateTime.plusHours(1);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(startDateTime)) {
+            return "예약 대기";
+        } else if (now.isAfter(endDateTime)) {
+            return "진행종료";
+        } else {
+            return "진행 중";
+        }
     }
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/dto/response/CodingZoneClassInfoResponseDto.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/dto/response/CodingZoneClassInfoResponseDto.java
@@ -1,0 +1,8 @@
+package com.icehufs.icebreaker.domain.codingzone.dto.response;
+public record CodingZoneClassInfoResponseDto(
+        String classTime,
+        String assistantName,
+        String groupId,
+        String classStatus,
+        int classNum
+) {}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/repository/CodingZoneClassRepository.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/repository/CodingZoneClassRepository.java
@@ -18,6 +18,8 @@ public interface CodingZoneClassRepository extends JpaRepository<CodingZoneClass
 
     List<CodingZoneClass> findAllByClassDate(String classDate);
 
+    List<CodingZoneClass> findBySubject_IdAndClassDate(int subjectId, String classDate);
+
     // 새로운 수업 등록 시 DB에 이미 있는 수업 정보 확인 과정에서 필요
     // classNumber와 currentNumber 제외하고 가져와야 함
     @Query("""

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
@@ -33,6 +33,9 @@ public interface CodingZoneService {
     ResponseEntity<? super GetCodingZoneAssitantListResponseDto> getAssistantList();
     AssistantNamesResponseDto getAssistantNamesBySubjectId(Long subjectId);
     CodingZoneClassNamesResponseDto getCodingZoneClassNamesByDate(String date);
-    //수업 코딩존 조교 
+    List<CodingZoneClassInfoResponseDto> findCodingZoneClassesBySubjectAndDate(Long subjectId, String date);
+
+    //수업 코딩존 조교
+
     ResponseEntity<? super PutAttendanceResponseDto> putAttend(Integer registNum, String email);
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -659,36 +659,16 @@ public class CodingZoneServiceImplement implements CodingZoneService {
         List<CodingZoneClassInfoResponseDto> classInfos = new ArrayList<>();
 
         for (CodingZoneClass codingZoneClass :codingZoneClasses){
-            String classStatus = calculateClassStatus(date, codingZoneClass.getClassTime());
-
             CodingZoneClassInfoResponseDto dto = new CodingZoneClassInfoResponseDto(
                     codingZoneClass.getClassTime(),
                     codingZoneClass.getAssistantName(),
                     groupInfRepository.findByClassNum(codingZoneClass.getClassNum()).getGroupId(),
-                    classStatus,
+                    codingZoneClass.calculateClassStatus(date),
                     codingZoneClass.getClassNum());
 
             classInfos.add(dto);
         }
         return classInfos;
-    }
-
-    private String calculateClassStatus(String date, String classTime) {
-        LocalDate classDate = LocalDate.parse(date); // "yyyy-MM-dd"
-        LocalTime startTime = LocalTime.parse(classTime); // "HH:mm:ss"
-
-        LocalDateTime startDateTime  = LocalDateTime.of(classDate, startTime);
-        LocalDateTime endDateTime  = startDateTime.plusHours(1);
-
-        LocalDateTime now = LocalDateTime.now();
-
-        if (now.isBefore(startDateTime)) {
-            return "예약 대기";
-        } else if (now.isAfter(endDateTime)) {
-            return "진행종료";
-        } else {
-            return "진행 중";
-        }
     }
 
 

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -659,7 +659,7 @@ public class CodingZoneServiceImplement implements CodingZoneService {
         List<CodingZoneClassInfoResponseDto> classInfoResponseDtos = new ArrayList<>();
 
         for (CodingZoneClass codingZoneClass :codingZoneClasses){
-            String classStatus = getClassStatus(date, codingZoneClass.getClassTime());
+            String classStatus = calculateClassStatus(date, codingZoneClass.getClassTime());
 
             CodingZoneClassInfoResponseDto dto = new CodingZoneClassInfoResponseDto(
                     codingZoneClass.getClassTime(),
@@ -673,20 +673,21 @@ public class CodingZoneServiceImplement implements CodingZoneService {
         return classInfoResponseDtos;
     }
 
-    private String getClassStatus(String date, String classTime) {
+    private String calculateClassStatus(String date, String classTime) {
         LocalDate classDate = LocalDate.parse(date); // "yyyy-MM-dd"
         LocalTime startTime = LocalTime.parse(classTime); // "HH:mm:ss"
-        LocalDateTime classStartDateTime = LocalDateTime.of(classDate, startTime);
-        LocalDateTime classEndDateTime = classStartDateTime.plusHours(1);
+
+        LocalDateTime startDateTime  = LocalDateTime.of(classDate, startTime);
+        LocalDateTime endDateTime  = startDateTime.plusHours(1);
 
         LocalDateTime now = LocalDateTime.now();
 
-        if (now.isAfter(classEndDateTime)) {
-            return "진행종료";
-        } else if (!now.isBefore(classStartDateTime) && !now.isAfter(classEndDateTime)) {
-            return "진행 중";
-        } else {
+        if (now.isBefore(startDateTime)) {
             return "예약 대기";
+        } else if (now.isAfter(endDateTime)) {
+            return "진행종료";
+        } else {
+            return "진행 중";
         }
     }
 

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -656,7 +656,7 @@ public class CodingZoneServiceImplement implements CodingZoneService {
     @Override
     public List<CodingZoneClassInfoResponseDto> findCodingZoneClassesBySubjectAndDate(Long subjectId, String date) {
         List<CodingZoneClass> codingZoneClasses = codingZoneClassRepository.findBySubject_IdAndClassDate(subjectId.intValue(), date);
-        List<CodingZoneClassInfoResponseDto> classInfoResponseDtos = new ArrayList<>();
+        List<CodingZoneClassInfoResponseDto> classInfos = new ArrayList<>();
 
         for (CodingZoneClass codingZoneClass :codingZoneClasses){
             String classStatus = calculateClassStatus(date, codingZoneClass.getClassTime());
@@ -668,9 +668,9 @@ public class CodingZoneServiceImplement implements CodingZoneService {
                     classStatus,
                     codingZoneClass.getClassNum());
 
-            classInfoResponseDtos.add(dto);
+            classInfos.add(dto);
         }
-        return classInfoResponseDtos;
+        return classInfos;
     }
 
     private String calculateClassStatus(String date, String classTime) {


### PR DESCRIPTION
## 📌 변경 사항
특정 날짜, 특정 교과목으로 등록한 코딩존 수업 정보 리스트를 반환하는 비지니스 로직을 추가했습니다.

## 🔍 상세 내용

### 날짜와 과목을 선택하면 코딩존 목록을 반환하는 API 통합

해당 api가 

- 출결 관리 - 조교 리스트 조회
- 코딩존 등록 조회 - 등록 리스트 조회

이 두 페이지에서 사용되고 있습니다.

두 페이지에서 사용하는 응답 형식에는 약간의 차이가 있습니다:

출결관리 페이지 응답 형식(data 부분만) :
``` json
{
  "classTime": "14:00:00",
  "assistantName": "박다영",
  "groupId": "A",
  "classNum": 1
}
```


수업등록 페이지 응답 형식:
``` json 
{
  "classTime": "14:00:00",
  "assistantName": "박다영",
  "groupId": "A",
  "classNum": 1,
  "classStatus": "진행종료"
}
```

차이는 오직 classStatus 필드의 존재 여부뿐입니다.
api 설계 기간에는 이 차이로 인해 API를 두 개로 분리해서 설계 하였는데,

굳이 나눌 필요 없이 classStatus를 포함하는 API로 통합하고,
출결관리 페이지에선 단순히 해당 값을 프론트에서 사용하지 않도록 처리하면
API 관리 측면에서 더 간결할 수 있겠다는 생각이 들었습니다.

따라서 하나의 url path로 통합해 아래 path로 get 요청을 처리하였습니다.
```
/api/admin/subjects/{subjectId}/codingzones?date=2024-07-16
```
### calculateClassStatus 메서드를 codingZoneClass 엔티티 내부에 캡슐화
감사합니다.


## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.

close #255 