### PR TITLE
[FE-#271] 레이아웃 및 CSS 수정

### DIFF
--- a/frontend/src/shared/ui/Banner/Banner.css
+++ b/frontend/src/shared/ui/Banner/Banner.css
@@ -4,7 +4,7 @@
   height: auto;
   padding: 0px 10px;
   box-sizing: border-box;
-  margin: 45px 0;
+  margin: 45px 0 0 0;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/frontend/src/shared/ui/Banner/Banner.css
+++ b/frontend/src/shared/ui/Banner/Banner.css
@@ -1,9 +1,10 @@
+/* 단일 배너 전용 */
 .banner_img_container {
   width: 100%;
   height: auto;
-  padding: 20px 10px;
+  padding: 0px 10px;
   box-sizing: border-box;
-  margin: 20px auto;
+  margin: 45px 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -11,6 +12,79 @@
 
 .banner_img_container .banner {
   width: auto;
-  max-width: 920px;
-  max-height: 330px;
+  max-width: auto;
+  max-height: 370px;
+}
+
+/* 슬라이더 배너 전용 */
+.codingzone-top-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.codingzonetop2-image {
+  width: 100%;
+  max-width: 1200px;
+  height: auto;
+  max-height: 400px;
+  object-fit: cover;
+  margin: -5px auto 0 auto;
+}
+
+/* 반응형 */
+/* ≤ 1280px 반응형 */
+@media (max-width: 1280px) {
+  .banner_img_container {
+    margin: 38px 0;
+  }
+  .banner_img_container .banner {
+    max-height: 296px;
+  }
+  .codingzonetop2-image {
+    max-width: 960px;
+    margin: -6px auto -10px auto;
+  }
+}
+
+/* ≤ 1024px 반응형 */
+@media (max-width: 1024px) {
+  .banner_img_container {
+    margin: 35px 0;
+  }
+  .banner_img_container .banner {
+    max-height: 237px;
+  }
+  .codingzonetop2-image {
+    max-width: 768px;
+    margin: -5px auto -13px auto;
+  }
+}
+
+/* ≤ 768px 반응형 */
+@media (max-width: 768px) {
+  .banner_img_container {
+    margin: 35px 0;
+  }
+  .banner_img_container .banner {
+    max-height: 240px;
+  }
+  .codingzonetop2-image {
+    max-width: 671px;
+    margin: -5px auto -10px auto;
+  }
+}
+
+/* ≤ 480px 반응형 */
+@media (max-width: 480px) {
+  .banner_img_container {
+    margin: 25px 0;
+  }
+  .banner_img_container .banner {
+    max-height: 150px;
+  }
+  .codingzonetop2-image {
+    max-width: 423px;
+    margin: 3px auto 1px auto;
+  }
 }

--- a/frontend/src/shared/ui/Banner/Banner.css
+++ b/frontend/src/shared/ui/Banner/Banner.css
@@ -4,7 +4,7 @@
   height: auto;
   padding: 0px 10px;
   box-sizing: border-box;
-  margin: 45px 0 0 0;
+  margin: 28px 0 0 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -13,7 +13,7 @@
 .banner_img_container .banner {
   width: auto;
   max-width: auto;
-  max-height: 370px;
+  max-height: 395px;
 }
 
 /* 슬라이더 배너 전용 */
@@ -25,66 +25,66 @@
 
 .codingzonetop2-image {
   width: 100%;
-  max-width: 1200px;
+  max-width: 1100px;
   height: auto;
   max-height: 400px;
   object-fit: cover;
-  margin: -5px auto 0 auto;
+  margin: -20px auto 0 auto;
 }
 
 /* 반응형 */
 /* ≤ 1280px 반응형 */
 @media (max-width: 1280px) {
   .banner_img_container {
-    margin: 38px 0;
+    margin: 28px 0 95px 0;
   }
   .banner_img_container .banner {
-    max-height: 296px;
+    max-height: 346px;
   }
   .codingzonetop2-image {
     max-width: 960px;
-    margin: -6px auto -10px auto;
+    margin: -16px auto -10px auto;
   }
 }
 
 /* ≤ 1024px 반응형 */
 @media (max-width: 1024px) {
   .banner_img_container {
-    margin: 35px 0;
+    margin: 25px 0 85px 0;
   }
   .banner_img_container .banner {
-    max-height: 237px;
+    max-height: 288px;
   }
   .codingzonetop2-image {
-    max-width: 768px;
-    margin: -5px auto -13px auto;
+    max-width: 795px;
+    margin: -15px auto -13px auto;
   }
 }
 
 /* ≤ 768px 반응형 */
 @media (max-width: 768px) {
   .banner_img_container {
-    margin: 35px 0;
+    margin: 23px 0 58px 0;
   }
   .banner_img_container .banner {
     max-height: 240px;
   }
   .codingzonetop2-image {
     max-width: 671px;
-    margin: -5px auto -10px auto;
+    margin: -14px auto -10px auto;
   }
 }
 
 /* ≤ 480px 반응형 */
 @media (max-width: 480px) {
   .banner_img_container {
-    margin: 25px 0;
+    margin: 20px 0 38px 0;
   }
   .banner_img_container .banner {
     max-height: 150px;
   }
   .codingzonetop2-image {
     max-width: 423px;
-    margin: 3px auto 1px auto;
+    margin: -4.5px auto 1px auto;
   }
 }

--- a/frontend/src/shared/ui/boardbar/CodingZoneBoardbar.css
+++ b/frontend/src/shared/ui/boardbar/CodingZoneBoardbar.css
@@ -1,112 +1,131 @@
-.button-container,
+/* 버튼 컨테이너 */
 .cza_button_container {
-  display: flex;
+  display: flex; /* 기본값 : row */
   width: 100%;
-  height: 60px;
-  padding: 16px 0;
+  margin: 1.37rem 0 1.0625rem 0;
   justify-content: center;
   align-items: center;
-
-  flex-shrink: 0;
+  gap: 1.875rem;
 }
 
-.cza_button_container button + button {
-  position: relative; /* pseudo-element 위치기준 */
-  margin-left: 21px; /* 기존 gap 그대로 */
-  padding-left: 21px; /* 경계선과 텍스트 간격 확보 */
-  border-left: 1px solid #868181; /* divider 역할 */
-}
-
+/* 버튼 공통 */
 .btn-attend {
   display: flex;
-  padding: 0.6rem 1.2rem;
-  border: 1px solid #838181a8;
-  background-color: rgba(255, 255, 255, 0);
-  color: #adacac;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background-color 0.3s, color 0.3s;
-  min-width: 147px;
-  width: 147px;
-  height: 60px;
-
-  box-sizing: border-box;
-  border-radius: 10px;
-  border: 1.5px solid #adacac;
   align-items: center;
   justify-content: center;
-}
-
-.btn-attend.active,
-.btn-attend.manage,
-.btn-attend.manage_all,
-.btn-attend.manage_class {
-  background-color: #052940;
-  color: #ffffff;
-  border-radius: 10px;
-  border: 1.5px solid #052940;
-  box-shadow: 0px 0px 3px #0b4264;
-  font-weight: 530;
-  padding: 0.6rem 1.2rem;
-  font-size: 1rem;
-  min-width: 147px;
-  width: 147px;
-  width: auto;
   box-sizing: border-box;
+
+  font-size: 1rem;
+  font-weight: 400;
+  color: #adacac;
+  padding: 0.875em 1.5625em;
+
+  border: 0.0625em solid #adacac;
+  border-radius: 0.625em;
+  background-color: #fff;
+
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease,
+    border-color 0.2s ease;
 }
 
+/* 세로 구분선 */
 .divider {
-  width: 1px;
-  height: 40px; /* 버튼 높이에 맞춤 */
-  background-color: #868181;
-  margin: 0 12px;
+  width: 0.0625em;
+  background: #868181;
+  align-self: stretch;
+  opacity: 0.6;
 }
 
+/* 활성 상태 */
+.btn-attend.active,
+.btn-attend:hover,
+.btn-attend:active {
+  background-color: #052940;
+  color: #fff;
+  border-color: #052940;
+  font-weight: 600;
+}
+
+/* 일반 학생 전용 버튼 컨테이너 */
+.cza_button_container.student {
+  margin: 2.5rem 0 1.5rem 0;
+}
+
+/* 일반 학생 전용 버튼 */
+.btn-attend.student {
+  padding: 1em 1.7em;
+}
+
+/* 반응형 */
+/* ≤ 1280px 반응형 */
+@media (max-width: 1280px) {
+  .cza_button_container {
+    margin: 0 0 0.84rem 0;
+  }
+  .btn-attend {
+    font-size: 00.875rem;
+  }
+  .cza_button_container.student {
+    margin: 0rem 0 1.7rem 0;
+  }
+}
+
+/* ≤ 1024px 반응형 */
+@media (max-width: 1024px) {
+  .cza_button_container {
+    margin: 0.4rem 0 0.7rem 0;
+  }
+  .btn-attend {
+    font-size: 0.8125rem;
+  }
+  .cza_button_container.student {
+    margin: 0.1rem 0 1.6rem 0;
+  }
+}
+
+/* ≤ 768px 반응형 */
 @media (max-width: 768px) {
-  .btn-attend {
-    padding: 0.5rem 1rem;
-    font-size: 0.9rem;
-    min-width: 70px;
-    max-width: 90px;
-  }
-
-  .btn-attend.active,
-  .btn-attend.manage,
-  .btn-attend.manage_all,
-  .btn-attend.manage_class {
-    padding: 0.5rem 1rem;
-    font-size: 0.9rem;
-    min-width: 70px;
-    max-width: 90px;
-  }
-
-  .button-container,
   .cza_button_container {
-    margin-top: 15px;
+    margin: 0.3rem 0 0.65rem 0;
+  }
+  .btn-attend {
+    font-size: 0.75rem;
+  }
+  .cza_button_container.student {
+    margin: 0.1rem 0 1.6rem 0;
   }
 }
 
-/* 모바일 화면 */
+/* ≤ 480px 반응형 */
 @media (max-width: 480px) {
-  .btn-attend {
-    padding: 0.4rem 0.8rem;
-    font-size: 0.8rem;
-    min-width: 60px;
-    max-width: 80px; /* max-width을 80px으로 감소 */
-  }
-
-  .btn-attend.active,
-  .btn-attend.manage,
-  .btn-attend.manage_all,
-  .btn-attend.manage_class {
-    padding: 0.4rem 0.8rem;
-    font-size: 0.8rem;
-    min-width: 60px;
-    max-width: 80px;
-  }
-
-  .button-container,
   .cza_button_container {
-    margin-top: 10px;
+    flex-wrap: wrap; /* 줄바꿈 허용 */
+    justify-content: center;
+    gap: 0.75rem;
+    margin: 0.7rem 0 0.72rem 0;
+  }
+
+  /* 세로 구분선 숨김 */
+  .cza_button_container .divider {
+    display: none;
+  }
+
+  /* 버튼을 2개씩 한 줄에 배치 */
+  .btn-attend {
+    flex: 0 1 calc(35% - 0.75rem);
+    width: calc(35% - 0.75rem);
+    min-width: unset; /* 데스크톱용 최소폭 해제 */
+    padding: 0.65rem 0.5rem;
+    font-size: 0.75rem;
+  }
+  .cza_button_container.student {
+    margin: 0.35rem 0 1.5rem 0;
+  }
+
+  .cza_button_container.student .btn-attend.student {
+    flex: 0 0 auto;
+    width: auto;
+    padding: 0.6rem 1.2rem !important;
   }
 }

--- a/frontend/src/shared/ui/boardbar/CodingZoneBoardbar.css
+++ b/frontend/src/shared/ui/boardbar/CodingZoneBoardbar.css
@@ -2,10 +2,11 @@
 .cza_button_container {
   display: flex; /* 기본값 : row */
   width: 100%;
-  margin: 1.37rem 0 1.0625rem 0;
+  margin: 3.4rem 0 1.0625rem 0;
   justify-content: center;
   align-items: center;
   gap: 1.875rem;
+  flex-wrap: nowrap;
 }
 
 /* 버튼 공통 */
@@ -27,10 +28,12 @@
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease,
     border-color 0.2s ease;
+  white-space: nowrap;
 }
 
 /* 세로 구분선 */
 .divider {
+  flex: 0 0 0.0625rem;
   width: 0.0625em;
   background: #868181;
   align-self: stretch;
@@ -50,11 +53,17 @@
 /* 일반 학생 전용 버튼 컨테이너 */
 .cza_button_container.student {
   margin: 2.5rem 0 1.5rem 0;
+  margin-inline: auto;
 }
 
 /* 일반 학생 전용 버튼 */
 .btn-attend.student {
-  padding: 1em 1.7em;
+  padding: 0.85em 1.6em;
+  margin-inline: auto;
+}
+/* 학생 전용일 땐 구분선 제거 */
+.cza_button_container.student .divider {
+  display: none;
 }
 
 /* 반응형 */
@@ -64,7 +73,7 @@
     margin: 0 0 0.84rem 0;
   }
   .btn-attend {
-    font-size: 00.875rem;
+    font-size: 0.9rem;
   }
   .cza_button_container.student {
     margin: 0rem 0 1.7rem 0;
@@ -77,7 +86,7 @@
     margin: 0.4rem 0 0.7rem 0;
   }
   .btn-attend {
-    font-size: 0.8125rem;
+    font-size: 0.74rem;
   }
   .cza_button_container.student {
     margin: 0.1rem 0 1.6rem 0;
@@ -87,10 +96,10 @@
 /* ≤ 768px 반응형 */
 @media (max-width: 768px) {
   .cza_button_container {
-    margin: 0.3rem 0 0.65rem 0;
+    margin: 0.7rem 0 0.7rem 0;
   }
   .btn-attend {
-    font-size: 0.75rem;
+    font-size: 0.7rem;
   }
   .cza_button_container.student {
     margin: 0.1rem 0 1.6rem 0;
@@ -103,7 +112,7 @@
     flex-wrap: wrap; /* 줄바꿈 허용 */
     justify-content: center;
     gap: 0.75rem;
-    margin: 0.7rem 0 0.72rem 0;
+    margin: 0.7rem 0 0.35rem 0;
   }
 
   /* 세로 구분선 숨김 */
@@ -111,13 +120,12 @@
     display: none;
   }
 
-  /* 버튼을 2개씩 한 줄에 배치 */
   .btn-attend {
-    flex: 0 1 calc(35% - 0.75rem);
-    width: calc(35% - 0.75rem);
+    flex: 0 1 calc(25% - 0.75rem);
+    width: calc(30% - 0.75rem);
     min-width: unset; /* 데스크톱용 최소폭 해제 */
-    padding: 0.65rem 0.5rem;
-    font-size: 0.75rem;
+    padding: 0.5rem 0.7rem;
+    font-size: 0.55rem;
   }
   .cza_button_container.student {
     margin: 0.35rem 0 1.5rem 0;

--- a/frontend/src/shared/ui/boardbar/CodingZoneBoardbar.js
+++ b/frontend/src/shared/ui/boardbar/CodingZoneBoardbar.js
@@ -4,6 +4,15 @@ import React, { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 import { getczauthtypetRequest } from "../../api/AuthApi";
 
+const ROUTES = {
+  attendanceEntry: "/coding-zone/Codingzone_Attendance",
+  attendanceReal: "/coding-zone/Codingzone_Attendance_Real",
+  classRegist: "/coding-zone/Coding-class-regist", // ← App 라우터와 대소문자 동일
+  setting: "/coding-zone/Codingzone_Setting",
+  manager: "/coding-zone/Codingzone_Manager",
+  allAttend: "/coding-zone/Codingzone_All_Attend",
+};
+
 const CodingZoneBoardbar = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -70,14 +79,17 @@ const CodingZoneBoardbar = () => {
     return null;
   } // 로딩
 
-  // URL 경로로부터 activeButton 상태 자동 설정
   const getActiveButtonFromPath = () => {
-    const path = location.pathname;
-    if (path.includes("coding-class-regist")) return "manage_class";
-    if (path.includes("Codingzone_Setting")) return "setting";
-    if (path.includes("Codingzone_Manager")) return "manage";
-    if (path.includes("Codingzone_All_Attend")) return "manage_all";
-    if (path.includes("Codingzone_Attendance")) return "check";
+    const p = location.pathname.toLowerCase();
+    if (p.startsWith(ROUTES.classRegist.toLowerCase())) return "manage_class";
+    if (p.startsWith(ROUTES.setting.toLowerCase())) return "setting";
+    if (p.startsWith(ROUTES.manager.toLowerCase())) return "manage";
+    if (p.startsWith(ROUTES.allAttend.toLowerCase())) return "manage_all";
+    if (
+      p.startsWith(ROUTES.attendanceEntry.toLowerCase()) ||
+      p.startsWith(ROUTES.attendanceReal.toLowerCase())
+    )
+      return "check";
     return "";
   };
 
@@ -100,9 +112,7 @@ const CodingZoneBoardbar = () => {
             className={`btn-attend ${
               !showAdminButton && !showRegisterClassButton ? "student" : ""
             } ${activeButton === "check" ? "active" : ""}`}
-            onClick={() =>
-              handleNavigation("/coding-zone/Codingzone_Attendance")
-            }
+            onClick={() => handleNavigation(ROUTES.attendanceEntry)}
           >
             출결 확인
           </button>
@@ -117,7 +127,7 @@ const CodingZoneBoardbar = () => {
             className={`btn-attend ${
               activeButton === "manage_class" ? "active" : ""
             }`}
-            onClick={() => handleNavigation("/coding-zone/coding-class-regist")}
+            onClick={() => handleNavigation(ROUTES.classRegist)}
           >
             수업 등록
           </button>
@@ -129,9 +139,7 @@ const CodingZoneBoardbar = () => {
               className={`btn-attend ${
                 activeButton === "setting" ? "active" : ""
               }`}
-              onClick={() =>
-                handleNavigation("/coding-zone/Codingzone_Setting")
-              }
+              onClick={() => handleNavigation(ROUTES.setting)}
             >
               코딩존 설정
             </button>
@@ -147,7 +155,7 @@ const CodingZoneBoardbar = () => {
             className={`btn-attend ${
               activeButton === "manage" ? "active" : ""
             }`}
-            onClick={() => handleNavigation("/coding-zone/Codingzone_Manager")}
+            onClick={() => handleNavigation(ROUTES.manager)}
           >
             출결 관리
           </button>
@@ -158,9 +166,7 @@ const CodingZoneBoardbar = () => {
             className={`btn-attend ${
               activeButton === "manage_all" ? "active" : ""
             }`}
-            onClick={() =>
-              handleNavigation("/coding-zone/Codingzone_All_Attend")
-            }
+            onClick={() => handleNavigation(ROUTES.allAttend)}
           >
             전체 관리
           </button>

--- a/frontend/src/shared/ui/navigation/CodingZoneNavigation.css
+++ b/frontend/src/shared/ui/navigation/CodingZoneNavigation.css
@@ -1,4 +1,4 @@
-.cz-nav-wrapper { 
+.cz-nav-wrapper {
   padding: 10px 20px;
   display: flex;
   justify-content: center;
@@ -17,7 +17,7 @@
   background-color: transparent;
   border: none;
   font-size: 16px;
-  color: #002D56;
+  color: #002d56;
   padding: 10px 20px;
   border-radius: 9999px;
   font-weight: 400;
@@ -32,7 +32,7 @@
 }
 
 .cz-nav-button.selected {
-  background-color: #002D56;
+  background-color: #002d56;
   color: white;
 }
 

--- a/frontend/src/shared/ui/navigation/CodingZoneNavigation.css
+++ b/frontend/src/shared/ui/navigation/CodingZoneNavigation.css
@@ -1,81 +1,82 @@
-.cz-nav-wrapper {
-  padding: 10px 20px;
+.select-container {
   display: flex;
   justify-content: center;
-  max-width: 800px;
-  margin: 20px auto;
-}
-
-.cz-nav-container {
-  display: flex;
-  gap: 60px;
   align-items: center;
-  flex-wrap: wrap; /* 작은 화면에서는 버튼들이 자동으로 줄바꿈 */
+  gap: 19rem;
+}
+.cz-nav-btn {
+  flex: 0 0 auto !important; /* flex:1로 늘어나는 것 방지 */
+  width: auto !important; /* width 고정/100% 제거 */
+  padding: 0.8125em 1.75em;
+  border-radius: 6.25em;
 }
 
-.cz-nav-button {
-  background-color: transparent;
-  border: none;
-  font-size: 16px;
-  color: #002d56;
-  padding: 10px 20px;
-  border-radius: 9999px;
-  font-weight: 400;
-  transition: all 0.3s ease;
-  flex: 1 1 auto; /* 버튼이 작은 화면에서 자연스럽게 크기 조절됨 */
-  text-align: center;
+.cz-nav-btn.btn-codingzone,
+.cz-nav-btn.btn-attendence,
+.cz-nav-btn.btn-inquiry {
+  background-color: #efefef;
+  color: #052940 !important;
+  font-size: 1rem;
+  font-weight: 500;
 }
 
-.cz-nav-button:hover {
-  cursor: pointer;
-  background-color: #e1e7ec;
+.cz-nav-btn:hover,
+.cz-nav-btn:active,
+.cz-nav-btn.selected,
+.cz-nav-btn[aria-pressed="true"],
+.cz-nav-btn:focus-visible {
+  background: #052940;
+  color: #fff !important;
+  border-color: #052940;
+  outline: none;
+  font-weight: 600 !important;
 }
 
-.cz-nav-button.selected {
-  background-color: #002d56;
-  color: white;
-}
-
-/* 📱 모바일 대응 */
-@media (max-width: 600px) {
-  .cz-nav-wrapper {
-    max-width: 100%;
-    padding: 8px 10px;
+/* 반응형 */
+/* ≤ 1280px 반응형 */
+@media (max-width: 1280px) {
+  .select-container {
+    gap: 15.5rem;
   }
-
-  .cz-nav-container {
-    gap: 10px;
-  }
-
-  .cz-nav-button {
-    font-size: 14px;
-    padding: 8px 12px;
+  .cz-nav-btn.btn-codingzone,
+  .cz-nav-btn.btn-attendence,
+  .cz-nav-btn.btn-inquiry {
+    font-size: 0.9rem;
   }
 }
 
-/* 📱 작은 태블릿 대응 */
+/* ≤ 1024px 반응형 */
+@media (max-width: 1024px) {
+  .select-container {
+    gap: 12rem;
+  }
+  .cz-nav-btn.btn-codingzone,
+  .cz-nav-btn.btn-attendence,
+  .cz-nav-btn.btn-inquiry {
+    font-size: 0.85rem;
+  }
+}
+
+/* ≤ 768px 반응형 */
 @media (max-width: 768px) {
-  .cz-nav-container {
-    gap: 20px;
+  .select-container {
+    gap: 9.3rem;
   }
-
-  .cz-nav-button {
-    font-size: 15px;
-    padding: 8px 14px;
+  .cz-nav-btn.btn-codingzone,
+  .cz-nav-btn.btn-attendence,
+  .cz-nav-btn.btn-inquiry {
+    font-size: 0.8rem;
   }
 }
 
-/* 💻 데스크톱 대응 */
-@media (min-width: 1024px) {
-  .cz-nav-wrapper {
-    max-width: 900px;
+/* ≤ 480px 반응형 */
+@media (max-width: 480px) {
+  .select-container {
+    gap: 4rem;
   }
-
-  .cz-nav-container {
-    gap: 80px;
-  }
-
-  .cz-nav-button {
-    font-size: 16px;
+  .cz-nav-btn.btn-codingzone,
+  .cz-nav-btn.btn-attendence,
+  .cz-nav-btn.btn-inquiry {
+    font-size: 0.65rem;
   }
 }

--- a/frontend/src/shared/ui/navigation/CodingZoneNavigation.js
+++ b/frontend/src/shared/ui/navigation/CodingZoneNavigation.js
@@ -1,35 +1,56 @@
 import InquiryModal from "../../../pages/Coding-zone/InquiryModal"; // 경로는 실제 구조에 따라 조정
-import "../../../pages/css/codingzone/codingzone-main.css";
+import "../../../shared/ui/navigation/CodingZoneNavigation.css";
 import { useLocation, useNavigate } from "react-router-dom";
 import React, { useEffect, useState } from "react";
+
+const ROUTES = {
+  codingzone: "/coding-zone",
+  attendenceEntry: "/coding-zone/Codingzone_Attendance", // 분기용(필요시)
+  attendenceReal: "/coding-zone/Codingzone_Attendance_Real", // 학생용
+  manager: "/coding-zone/Codingzone_Manager", // 조교용
+  allAttend: "/coding-zone/Codingzone_All_Attend", // 과사 조교(EA)용
+  classRegist: "/coding-zone/Coding-class-regist", // 보드바-수업 등록 ㅇ
+  setting: "/coding-zone/Codingzone_Setting", // 보드바-코딩존 설정
+};
 
 const CodingZoneNavigation = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const [selectedButton, setSelectedButton] = useState("codingzone");
+  // 초기 값을 경로 기반으로 계산
+  const computeSelected = (path) => {
+    const p = path.replace(/\/+$/, "").toLowerCase();
+    const isAttendance =
+      p.startsWith(ROUTES.attendenceEntry.toLowerCase()) ||
+      p.startsWith(ROUTES.attendenceReal.toLowerCase()) ||
+      p.startsWith(ROUTES.manager.toLowerCase()) ||
+      p.startsWith(ROUTES.allAttend.toLowerCase()) ||
+      p.startsWith(ROUTES.classRegist.toLowerCase()) ||
+      p.startsWith(ROUTES.setting.toLowerCase());
+    return isAttendance ? "attendence" : "codingzone";
+  };
+
+  const [selectedButton, setSelectedButton] = useState(() =>
+    computeSelected(location.pathname)
+  );
+
   const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
-    if (location.pathname === "/coding-zone") {
-      setSelectedButton("codingzone");
-    } else if (
-      location.pathname.includes("/coding-zone/Codingzone_Attendance")
-    ) {
-      setSelectedButton("attendence");
-    }
-  }, [location.pathname]);
+    if (showModal) return; // 모달 열려있으면 '문의하기' 유지
+    setSelectedButton(computeSelected(location.pathname));
+  }, [location.pathname, showModal]);
 
   const handleTabChange = (tab) => {
-    if (tab === "attendence" && !document.cookie.includes("accessToken")) {
-      alert("로그인 후 이용 가능합니다.");
-      return;
-    }
-    setSelectedButton(tab);
-    if (tab === "codingzone") {
-      navigate("/coding-zone");
-    } else if (tab === "attendence") {
-      navigate("/coding-zone/Codingzone_Attendance");
+    if (tab === "attendence") {
+      // 로그인 체크를 계속 쓰고 싶으면 아래 3줄 유지 (아니면 통째로 삭제)
+      if (!document.cookie.includes("accessToken")) {
+        alert("로그인 후 이용 가능합니다.");
+        return;
+      }
+      navigate(ROUTES.attendenceEntry); // 권한 분기는 라우터에서 처리
+    } else {
+      navigate(ROUTES.codingzone);
     }
   };
 
@@ -44,31 +65,35 @@ const CodingZoneNavigation = () => {
 
   return (
     <div className="select-container">
-      <span> | </span>
       <button
         onClick={() => handleTabChange("codingzone")}
-        className={selectedButton === "codingzone" ? "selected" : ""}
+        className={`cz-nav-btn btn-codingzone ${
+          selectedButton === "codingzone" ? "selected" : ""
+        }`}
       >
         코딩존 예약
       </button>
-      <span> | </span>
+
       <button
         onClick={() => handleTabChange("attendence")}
-        className={selectedButton === "attendence" ? "selected" : ""}
+        className={`cz-nav-btn btn-attendence ${
+          selectedButton === "attendence" ? "selected" : ""
+        }`}
       >
         출결 관리
       </button>
-      <span> | </span>
+
       <button
         onClick={handleOpenModal}
-        className={selectedButton === "inquiry" ? "selected" : ""}
+        className={`cz-nav-btn btn-inquiry ${
+          selectedButton === "inquiry" ? "selected" : ""
+        }`}
       >
         문의 하기
       </button>
       {showModal && (
         <InquiryModal isOpen={showModal} onClose={handleCloseModal} />
       )}
-      <span> | </span>
     </div>
   );
 };

--- a/frontend/src/widgets/layout/Header/Navbar.css
+++ b/frontend/src/widgets/layout/Header/Navbar.css
@@ -1,24 +1,123 @@
+.navbar {
+  width: 100%;
+  padding: 0 110px;
+  margin: 0 0 20px 0;
+}
+
 .header-container {
   align-items: center;
-  width: 1600px;
-  min-width: 350px;
+  width: 100%;
+  max-width: 1600px;
   margin: 0 auto;
-  padding: 30px 0px 10px 11px;
-  position: relative;
+  padding: 55px 0 13px 11px;
   display: flex;
   justify-content: space-between;
   border-bottom: 1px solid #052940;
 }
+
 .header-container img {
-  margin-top: 0.5vw;
+  margin: 0;
   width: 140px;
-  height: 35px;
+  height: auto;
 }
 .navbar-nav {
   font-size: 13px;
 }
 
+.nav-actions {
+  display: flex;
+  flex-direction: row;
+  font-weight: bold;
+}
+
+/* 기본 색 + 전환 */
+nav.navbar .nav-link {
+  color: #052940 !important;
+  transition: opacity 0.2s ease;
+}
+
+/* hover/클릭 순간 */
+nav.navbar .nav-link:hover,
+nav.navbar .nav-link:active {
+  opacity: 0.5;
+}
+
+/* 모달 열린 동안 해당 링크만 계속 0.75 유지 */
+nav.navbar .nav-link[aria-expanded="true"],
+nav.navbar .nav-link[data-open="true"] {
+  opacity: 0.5;
+}
+
+/* ≤ 1280px */
+@media (max-width: 1280px) {
+  .navbar {
+    padding: 0 80px;
+    margin: 0 0 18px 0;
+  }
+  .header-container {
+    padding: 42px 0 11px 12px;
+  }
+  .header-container img {
+    width: 115px;
+  }
+  .navbar-nav {
+    font-size: 11px;
+  }
+}
+
+/* ≤ 1024px */
+@media (max-width: 1024px) {
+  .navbar {
+    padding: 0 60px;
+    margin: 0 0 16px 0;
+  }
+  .header-container {
+    padding: 35px 0 9px 13px;
+  }
+  .header-container img {
+    width: 105px;
+  }
+  .navbar-nav {
+    font-size: 10px;
+  }
+}
+
+/* ≤ 768px */
+@media (max-width: 768px) {
+  .navbar {
+    padding: 0 40px;
+    margin: 0 0 14px 0;
+  }
+  .header-container {
+    padding: 25px 0 7px 14px;
+  }
+  .header-container img {
+    width: 95px;
+  }
+  .navbar-nav {
+    font-size: 9px;
+  }
+}
+
+/* ≤ 480px */
+@media (max-width: 480px) {
+  .navbar {
+    padding: 0 20px;
+    margin: 0 0 12px 0;
+  }
+  .header-container {
+    padding: 17px 0 5px 15px;
+  }
+  .header-container img {
+    width: 75px;
+  }
+  .navbar-nav {
+    font-size: 6px;
+  }
+}
+
 /* ✅ 추가(juhui) : 익명 게시판 Navbar 배경색 수정  */
 .navbar.article-navbar {
   background-color: #eaeaf5;
+  margin: 0;
 }

--- a/frontend/src/widgets/layout/Header/Navbar.css
+++ b/frontend/src/widgets/layout/Header/Navbar.css
@@ -1,7 +1,7 @@
 .navbar {
   width: 100%;
   padding: 0 110px;
-  margin: 0 0 35px 0;
+  margin: 0 0 66px 0;
 }
 
 .header-container {
@@ -9,7 +9,7 @@
   width: 100%;
   max-width: 1600px;
   margin: 0 auto;
-  padding: 55px 0 13px 11px;
+  padding: 70px 0 13px 11px;
   display: flex;
   justify-content: space-between;
   border-bottom: 1px solid #052940;
@@ -17,11 +17,11 @@
 
 .header-container img {
   margin: 0;
-  width: 140px;
+  width: 165px;
   height: auto;
 }
 .navbar-nav {
-  font-size: 13px;
+  font-size: 0.85rem;
 }
 
 .nav-actions {
@@ -51,16 +51,16 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 1280px) {
   .navbar {
     padding: 0 80px;
-    margin: 0 0 31px 0;
+    margin: 0 0 54px 0;
   }
   .header-container {
-    padding: 42px 0 11px 12px;
+    padding: 89px 0 12px 12px;
   }
   .header-container img {
-    width: 115px;
+    width: 165px;
   }
   .navbar-nav {
-    font-size: 11px;
+    font-size: 0.8rem;
   }
 }
 
@@ -68,16 +68,16 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 1024px) {
   .navbar {
     padding: 0 60px;
-    margin: 0 0 28px 0;
+    margin: 0 0 45px 0;
   }
   .header-container {
-    padding: 35px 0 9px 13px;
+    padding: 70px 0 12px 13px;
   }
   .header-container img {
-    width: 105px;
+    width: 165px;
   }
   .navbar-nav {
-    font-size: 10px;
+    font-size: 0.8rem;
   }
 }
 
@@ -85,16 +85,16 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 768px) {
   .navbar {
     padding: 0 40px;
-    margin: 0 0 24px 0;
+    margin: 0 0 33px 0;
   }
   .header-container {
-    padding: 25px 0 7px 14px;
+    padding: 48px 0 8px 14px;
   }
   .header-container img {
-    width: 95px;
+    width: 125px;
   }
   .navbar-nav {
-    font-size: 9px;
+    font-size: 0.65rem;
   }
 }
 
@@ -102,16 +102,16 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 480px) {
   .navbar {
     padding: 0 20px;
-    margin: 0 0 21px 0;
+    margin: 0 0 25px 0;
   }
   .header-container {
-    padding: 17px 0 5px 15px;
+    padding: 28px 0 7px 15px;
   }
   .header-container img {
-    width: 75px;
+    width: 92px;
   }
   .navbar-nav {
-    font-size: 6px;
+    font-size: 0.53rem;
   }
 }
 

--- a/frontend/src/widgets/layout/Header/Navbar.css
+++ b/frontend/src/widgets/layout/Header/Navbar.css
@@ -30,25 +30,24 @@
   font-weight: bold;
 }
 
-/* 기본 색 + 전환 */
 nav.navbar .nav-link {
   color: #052940 !important;
   transition: opacity 0.2s ease;
 }
 
-/* hover/클릭 순간 */
+/* hover : 클릭 순간 */
 nav.navbar .nav-link:hover,
 nav.navbar .nav-link:active {
   opacity: 0.5;
 }
 
-/* 모달 열린 동안 해당 링크만 계속 0.75 유지 */
+/* 모달 열린 동안 해당 링크만 계속 0.5 유지 */
 nav.navbar .nav-link[aria-expanded="true"],
 nav.navbar .nav-link[data-open="true"] {
   opacity: 0.5;
 }
 
-/* ≤ 1280px */
+/* ≤ 1280px 반응형 */
 @media (max-width: 1280px) {
   .navbar {
     padding: 0 80px;
@@ -65,7 +64,7 @@ nav.navbar .nav-link[data-open="true"] {
   }
 }
 
-/* ≤ 1024px */
+/* ≤ 1024px 반응형 */
 @media (max-width: 1024px) {
   .navbar {
     padding: 0 60px;
@@ -82,7 +81,7 @@ nav.navbar .nav-link[data-open="true"] {
   }
 }
 
-/* ≤ 768px */
+/* ≤ 768px 반응형 */
 @media (max-width: 768px) {
   .navbar {
     padding: 0 40px;
@@ -99,7 +98,7 @@ nav.navbar .nav-link[data-open="true"] {
   }
 }
 
-/* ≤ 480px */
+/* ≤ 480px 반응형 */
 @media (max-width: 480px) {
   .navbar {
     padding: 0 20px;
@@ -116,7 +115,7 @@ nav.navbar .nav-link[data-open="true"] {
   }
 }
 
-/* ✅ 추가(juhui) : 익명 게시판 Navbar 배경색 수정  */
+/* 익명 게시판 Navbar 배경색 수정 및 margin 수정 */
 .navbar.article-navbar {
   background-color: #eaeaf5;
   margin: 0;

--- a/frontend/src/widgets/layout/Header/Navbar.css
+++ b/frontend/src/widgets/layout/Header/Navbar.css
@@ -1,7 +1,7 @@
 .navbar {
   width: 100%;
   padding: 0 110px;
-  margin: 0 0 20px 0;
+  margin: 0 0 35px 0;
 }
 
 .header-container {
@@ -51,7 +51,7 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 1280px) {
   .navbar {
     padding: 0 80px;
-    margin: 0 0 18px 0;
+    margin: 0 0 31px 0;
   }
   .header-container {
     padding: 42px 0 11px 12px;
@@ -68,7 +68,7 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 1024px) {
   .navbar {
     padding: 0 60px;
-    margin: 0 0 16px 0;
+    margin: 0 0 28px 0;
   }
   .header-container {
     padding: 35px 0 9px 13px;
@@ -85,7 +85,7 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 768px) {
   .navbar {
     padding: 0 40px;
-    margin: 0 0 14px 0;
+    margin: 0 0 24px 0;
   }
   .header-container {
     padding: 25px 0 7px 14px;
@@ -102,7 +102,7 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 480px) {
   .navbar {
     padding: 0 20px;
-    margin: 0 0 12px 0;
+    margin: 0 0 21px 0;
   }
   .header-container {
     padding: 17px 0 5px 15px;

--- a/frontend/src/widgets/layout/Header/Navbar.js
+++ b/frontend/src/widgets/layout/Header/Navbar.js
@@ -86,6 +86,7 @@ const NavBar = () => {
                       isActive ? "nav-link active" : "nav-link"
                     }
                     to="#"
+                    style={{ marginRight: "20px" }} // 스타일 동일하게 추가
                     onClick={handleLogout}
                   >
                     Log Out

--- a/frontend/src/widgets/layout/Header/Navbar.js
+++ b/frontend/src/widgets/layout/Header/Navbar.js
@@ -66,7 +66,7 @@ const NavBar = () => {
         </Link>
         <ul className="navbar-nav">
           <li className="nav-item">
-            <div style={{ display: "flex", fontWeight: "bold" }}>
+            <div className="nav-actions">
               {isLoggedIn ? (
                 <>
                   <NavLink
@@ -74,6 +74,8 @@ const NavBar = () => {
                       isActive ? "nav-link active" : "nav-link"
                     }
                     to="#"
+                    aria-expanded={modal.mypage}
+                    data-open={modal.mypage}
                     style={{ marginRight: "20px" }}
                     onClick={() => openModal("mypage")}
                   >
@@ -96,6 +98,8 @@ const NavBar = () => {
                       isActive ? "nav-link active" : "nav-link"
                     }
                     to="#"
+                    aria-expanded={modal.login}
+                    data-open={modal.login}
                     style={{ marginRight: "20px" }}
                     onClick={() => openModal("login")}
                   >
@@ -106,6 +110,8 @@ const NavBar = () => {
                       isActive ? "nav-link active" : "nav-link"
                     }
                     to="#"
+                    aria-expanded={modal.signup}
+                    data-open={modal.signup}
                     style={{ marginRight: "20px" }}
                     onClick={() => openModal("signup")}
                   >

--- a/frontend/src/widgets/layout/Header/Navbar.js
+++ b/frontend/src/widgets/layout/Header/Navbar.js
@@ -7,7 +7,7 @@ import MypageForm from "../../../features/auth/components/Modal/Mypage.js";
 import MyModal from "../../../shared/components/BaseModal.js";
 import { useCookies } from "react-cookie";
 import { logoutRequest } from "../../../entities/api/UserApi.js";
-import { useLocation } from "react-router-dom"; // ✅ 추가(juhui): 현재 경로 파악용 (익명게시판 페이지 여부 판단)
+import { useLocation } from "react-router-dom"; // 현재 경로 파악용 (익명게시판 페이지 여부 판단)
 
 const NavBar = () => {
   const [modal, setModal] = useState({
@@ -18,7 +18,7 @@ const NavBar = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [cookies, setCookie, removeCookie] = useCookies(["accessToken"]);
   const navigate = useNavigate();
-  // ✅ 추가(juhui): 경로가 '/article-main'으로 시작하면 익명게시판 페이지로 간주
+  // 경로가 '/article-main'으로 시작하면 익명게시판 페이지로 간주
   const location = useLocation();
   const isArticlePage = location.pathname.startsWith("/article-main");
 
@@ -58,7 +58,7 @@ const NavBar = () => {
   };
 
   return (
-    // ✅ 추가(juhui): 게시판 페이지일 때만 별도 스타일 클래스 적용
+    // 게시판 페이지일 때만 별도 스타일 클래스 적용
     <nav className={`navbar ${isArticlePage ? "article-navbar" : ""}`}>
       <div className="header-container">
         <Link className="header-school" to="/">


### PR DESCRIPTION
## 📌 변경 사항
### 1️⃣ Header(Navbar)
- 반응형 디자인 적용
- Sign In / Sign Up 또는 MyPage / Log Out 색상 변경 및 hover/active 적용

### 2️⃣ Banner
- 반응형 디자인 적용
- 배너 크기 조정

### 3️⃣ NavigationBar
- 버튼 하이라이트 개선
- 권한 분기 로직 제거
- 버튼 레이아웃 개선

### 4️⃣ BoardBar
- 버튼 하이라이트 개선
- 권한 분기 로직 개선
- 페이지 로딩 시 깜빡임 방지
- 버튼 레이아웃 개선

## 🔍 상세 내용
### 0️⃣ 공통 
**0. PR 정정 입니다..!**
- "feat: Navbar 컴포넌트 익명게시판 페이지 전용 스타일 적용 및 UX 개선" 커밋 두 개를 보실 수 있으실텐데, <br>가장 최근에 푸시된 커밋을 기준으로 봐주시면 됩니다. <br>코드 정리를 위해 이전에 푸시한 커밋을 취소하고, 수정 후 다시 푸시한 것입니다...!
- "feat: Navbar 컴포넌트 익명게시판 페이지 전용 스타일 적용 및 UX 개선"에서 feat이 아니라 refactor 입니다...
- "refector: 네비게이션바 UI 개선"에사 refector가 아니라 refactor 입니다...

**2. 반응형 스타일을 1280px, 1024px, 768px, 480px로 기준을 잡고 세분화하였습니다.**
  - **<= 1280px :** 대형 모니터 ~ 소형 노트북
  - **<= 1024px :** 태블릿 가로 모드 또는 12인치 이하 노트북
  - **<= 768px :** 태블릿 세로 모드 / 대형 모바일 해상도
  - **<= 480px :** 소형 모바일(스마트폰)

**3. font-size의 최소 크기를 0.6rem(약 9.6px), 최대 크기를 1rem(16px)으로 잡고 반응형 UI를 구현하였습니다.**
  - **최소 크기(0.6rem)**: Apple 모바일 브라우저 가이드라인 및 WCAG 접근성 기준을 참고하여, <br>모바일 환경에서 가독성을 확보할 수 있는 최소 크기로 지정
  - **최대 크기(1rem)**: 기존 디자인의 폰트 크기가 다소 작다는 의견을 반영하여,<br> 데스크톱 환경에서 가독성과 디자인 균형을 유지할 수 있는 표준 크기로 설정

**4. 디자인 의도 및 수정 내용입니다.**
 - 피그마 디자인과 같이 NavigationBar와 BoardBar를 세로 가운데 정렬해보았으나, 시각적으로 눈에 잘 띄지 않는 문제가 있었습니다. 
 - 이에 각 Bar 위·아래 여백을 비대칭으로 조정하여, 두 Bar가 명확히 구분되도록 시각적인 구분감을 주었습니다.

 - 피그마 디자인상 NavigationBar의 버튼은 기본적으로 텍스트만 있는 형태지만, <br>실제 로컬 환경에서 확인했을 때 버튼처럼 인식되지 않는 문제가 있었습니다.  
 - 이를 개선하기 위해 버튼 기본 디자인에 회색 배경을 추가하여 시각적으로 버튼임을 명확히 하고자 했습니다.

**5. 과사 조교 권한 페이지의 BoardBar도 반응형 스타일 적용했습니다.**
- 과사 조교님 페이지는 원래 반응형 스타일을 적용하지 않아도 되는 것은 알고 있었으나,<br>공통 컴포넌트를 반응형으로 구현하는 과정에서 해당 페이지의 BoardBar만 적용되지 않아 전체적으로 미완성처럼 보였습니다. 
- 이에, 통일성과 완성도를 위해 출결 관리 페이지의 BoardBar에도 반응형 스타일을 적용하였습니다.

### 1️⃣ Header(Navbar)
**1. `padding`, `margin`, `border-bottom` 등 레이아웃 속성을 재조정하였습니다.**
  - 이 과정에서 기존에 반응형 스타일이 적용되지 않아 발생했던 디자인 불일치 문제를 해결하였습니다.

 **2. `nav.navbar` `.nav-link`에 hover/active 시 `opacity 0.5` 적용하였습니다.**
   - `aria-expanded="true"`, `data-open="true"` 속성을 활용하여, <br>모달(Sign In / Sign Up / My Page)이 열려 있는 동안에도 동일한 스타일이 유지되도록 개선하였습니다.

**3. 익명 게시판 전용 Navbar스타일을 추가하였습니다.**
- /article-main 경로 진입 시 `.navbar.article-navbar`클래스 부여하고, <br>해당 클래스에서 배경색을 익명 게시판의 배경색과 동일한 `#eaeaf5`로 변경하였습니다.
- 공통 Navbar의 margin 제거하여 익명 게시판에 margin으로 인해 흰 배경이 나타나는 것을 방지하였습니다.

### 2️⃣ Banner
**1.  기존 디자인의 배너 크기가 작다는 의견을 반영하여, 배너의 크기를 증가시켰습니다.**
  - `.banner`에 `max-height`, `max-width`를 지정하여 해상도별 이미지 크기 비율이 유지되도록 설정하였습니다.
    - **단일 배너(출결 관리 페이지)** : 세로 기준 비율 유지 -> `max-height`사용
    - **슬라이더 배너(코딩존 예약페이지)** : 가로 기준 비율 유지 -> `max-width` 사용

**2.  슬라이더 배너와 단일 배너의 가로 길이를 맞춰 크기를 조정하였습니다.**
  - 제가 피그마에서 디자인할 때, 모든 페이지의 body 영역 가로 길이을 배너의 가로 길이에 맞춰서 디자인을 했기 때문에, <br>각 페이지의 UI를 구현하실 때 배너의 가로 길이에 맞춰서 구현해 주시면 좋을 것 같습니다!

### 3️⃣ NavigationBar
**1. URL 기반으로 네비게이션 버튼의 하이라이트 상태를 계산하도록 수정했습니다.**
- **"출결 관리" 버튼 클릭 시, 페이지 이동 과정에서 <br>잠시 "코딩존 예약" 버튼이 하이라이트되었다가 다시 "출결 관리" 버튼으로 변경되는 현상을 발견하였습니다.**
  - `computeSelected()` 함수를 만들어서, 현재 경로를 분석해 어떤 버튼이 활성화될지 결정하여 위와 같은 현상을 없애고자 하였습니다.
  - `useState(() => computeSelected(pathname))`로 초기값을 설정하여 첫 렌더부터 올바른 하이라이트를 표시하였습니다.

- **"문의 하기" 버튼을 누르면 해당 버튼을 누른 당시에만 하이라이트되고, 모달이 열리면 하이라이트가 해제되는 현상을 발견하였습니다.**
  - `if (showModal) return;` 를 통해 모달이 열려 있는 동안에는 네비게이션 하이라이트가 변경되지 않도록 고정했습니다.
  - `setShowModal(false) + setSelectedButton(computeSelected(pathname))` 를 통해 <br>모달을 닫으면 현재 경로에 맞춰 하이라이트를 복원하도록 하였습니다.

**2. 권한 분기 로직을 네비게이션에서 제거했습니다.**
- ‘출결 관리’ 버튼은 항상 엔트리 경로(/Codingzone_Attendance)로만 이동하도록 변경하였습니다.
- 최종 목적지는 라우터에서 역할별로 분기되도록 하여, 네비게이션 쪽 로직을 간단하게 만들었습니다.
- 권한 처리를 라우터로 일원화하여 유지보수성을 높이고자 하였습니다.

**3. 버튼 레이아웃과 스타일을 개선했습니다.**
- 기존 px 단위를 rem 단위로 변환하여 반응형 대응성을 강화하고자 하였습니다.
- 해상도 구간별 버튼 간격과 폰트 크기를 조정하였습니다.

### 4️⃣ BoardBar
**1. 경로 기반으로 보드바 버튼의 하이라이트 상태를 계산하도록 수정했습니다.**
- **"출결 관리" 버튼 클릭 시, 이동 과정에서 보드바의 어떤 버튼도 활성화되지 않는 상태가 잠깐 발생하는 현상을 발견하였습니다.**
  - 기존 코드에는 /Codingzone_Attendance_Real, /Codingzone_Manager 등 최종 목적지 경로만 매칭 조건에 포함되어 있었고,<br>
클릭 직후 거치는 엔트리 경로(/Codingzone_Attendance)는 매칭되지 않아 활성화되지 않은 것이었습니다.
  - `getActiveButtonFromPath()` 로직에 엔트리 경로(/Codingzone_Attendance)를 포함하여,<br>
클릭 직후에도 즉시 올바른 버튼이 하이라이트되도록 수정하였습니다.

- **기존 코드의 경로 대소문자 불일치로 인해 ‘수업 등록’ 버튼이 활성화되지 않는 문제를 해결하였습니다.**
  - 모든 경로를 ROUTES 상수로 관리하고, 비교 시 `.toLowerCase()`를 적용하였습니다.

**2. 권한 분기 및 라우팅 로직을 개선했습니다.**
- **페이지 이동(또는 새로고침) 시 보드바가 잠깐 1개 버튼만 표시되었다가, <br>권한 반영 후 4개 버튼으로 늘어나는 깜빡임 현상을 발견하였습니다.**
  - `sessionStorage`에 저장된 권한 코드를 우선 적용하여, 서버 응답 전에도 올바른 버튼 구성을 표시하도록 수정하였습니다.
  - 서버 응답이 도착하면 `sessionStorage`를 갱신하고, `applyFlags()`를 재호출하여 버튼 상태를 최신화하였습니다.
  - 캐시와 응답 모두 없을 경우에는 초기 렌더를 지연시켜 깜빡임을 방지하였습니다.

- **"출결 관리" 버튼 클릭 시 "출결 관리" 페이지로 이동은 하였지만, 보드바의 아무런 버튼도 활성화 되지 않는 문제를 발견하였습니다.** 
  - 기존에는 엔트리 경로(/Codingzone_Attendance)에서 최종 경로(/Codingzone_Attendance_Real)로 이동하는 동안 <br>버튼 활성화 상태가 잠시 공백이 되었습니다.
  - `getActiveButtonFromPath()`에서 두 경로 모두 인식하도록 수정하여 페이지 전환 중에도 활성 상태가 유지되도록 하였습니다.

- 버튼 클릭 시 모든 경로 이동을 ROUTES 상수를 통해 처리하여 코드 일관성을 높이고자 하였습니다.

**3. 버튼 레이아웃 및 스타일을 개선했습니다.**
- **기존에 구현된 버튼이 페이지에 비해 크다는 의견과 <br>반응형 스타일이 코드에 구현되어 있지 않아 모바일 환경에서 버튼이 UI적으로 부자연스럽다는 의견을 반영하여 수정하고자 하였습니다.**
  - 해상도 구간별 버튼 간격, 여백, 폰트 크기를 조정하여 화면 크기에 따라 버튼이 자연스럽게 배치되도록 수정하였습니다.
  - 모바일 환경에서는 세로 구분선을 제거하여 버튼이 모두 한줄에 위치하도록 하였고 , <br>flex-wrap: nowrap;을 적용하여 버튼 안의 텍스트가 줄바꿈 되지 않도록 하였습니다. 

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 반응형 환경에서 버튼 크기, 간격, 폰트 크기가 적절한지 확인 부탁드립니다!
- 각 버튼 활성화 상태가 페이지 전환·새로고침 시 정상적으로 유지되는지 확인 부탁드립니다!
- getActiveButtonFromPath() 및 권한 캐싱 로직 변경이 올바르게 동작하는지 확인 부탁드립니다!
- ROUTES 경로와 URL 대소문자 처리 방식이 적절하게 적용되었는지 확인 부탁드립니다!

## 📎 참고 자료 (선택)
여러 해상도의 스크린샷을 모두 첨부하면 가독성이 떨어질 것 같아서, 
웹 버전과 모바일 버전의 스크린샷만 첨부했습니다!

### 1. 코딩존 예약 페이지
<img width="1470" height="956" alt="스크린샷 2025-08-11 오전 5 16 23" src="https://github.com/user-attachments/assets/e401b959-7293-4fed-857c-368bbccace44" />

### 2. 출결 관리 페이지 (일반 학생)
<img width="1470" height="956" alt="스크린샷 2025-08-11 오전 5 16 30" src="https://github.com/user-attachments/assets/6a674f0d-772e-4733-b0a9-8c965ffd0208" />

### 3. 출결 관리 페이지 (과사 조교)
<img width="1470" height="956" alt="스크린샷 2025-08-11 오전 5 22 28" src="https://github.com/user-attachments/assets/0477dfe4-26c4-4450-94ed-c4ab0b1d1c18" />

### 4. 코딩존 예약 페이지 (모바일 ver)
<img width="716" height="835" alt="스크린샷 2025-08-11 오전 5 20 08" src="https://github.com/user-attachments/assets/e3d610dd-d0e4-4079-9cfc-b62ca3b962d5" />

### 5. 출결 관리 페이지 (일반 학생, 모바일 ver)
<img width="663" height="835" alt="스크린샷 2025-08-11 오전 5 20 21" src="https://github.com/user-attachments/assets/232d4fc3-6f06-4e69-9178-51f4f9cf7a31" />

### 6. 출결 관리 페이지 (과사 조교, 모바일 ver)
<img width="754" height="838" alt="스크린샷 2025-08-11 오전 5 21 30" src="https://github.com/user-attachments/assets/5526622c-8141-4709-8235-607355a49d57" />
