### PR TITLE
[BE-#304] 코딩존 특정 수업 삭제 API 리펙토링

### DIFF
--- a/backend/src/main/java/com/icehufs/icebreaker/common/ResponseCode.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/common/ResponseCode.java
@@ -33,6 +33,8 @@ public interface ResponseCode {
     String NO_CODINGZONE_DATE = "NO_CODINGZONE_DATE";
     String NOT_MODIFIED_INFO = "NOT_MODIFIED_INFO";
     String DELETE_NOT_ALLOW = "DELETE_NOT_ALLOW";
+    String ALREADY_RESERVED_CLASS = "ALREADY_RESERVED_CLASS";
+    String NOT_FOUND_CLASS = "NOT_FOUND_CLASS";
 
     // HTTP Status 401
     String SIGN_IN_FAIL = "SF";

--- a/backend/src/main/java/com/icehufs/icebreaker/common/ResponseMessage.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/common/ResponseMessage.java
@@ -33,6 +33,8 @@ public interface ResponseMessage {
     String NOT_WEEKDAY = "입력한 날짜가 주중이 아님";
     String NOT_MODIFIED_INFO = "변경된 정보가 없음";
     String DELETE_NOT_ALLOW = "해당 코딩존 번호를 사용하는 수업이 등록되어 있습니다. 먼저 해당 수업을 삭제해주세요.";
+    String ALREADY_RESERVED_CLASS = "이미 해당 수업을 예약한 학생이 있으므로, 등록 취소가 불가능한 수업입니다.";
+    String NOT_FOUND_CLASS = "해당 코딩존 수업이 없습니다.";
 
 
     // HTTP Status 401

--- a/backend/src/main/java/com/icehufs/icebreaker/common/ResponseMessage.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/common/ResponseMessage.java
@@ -8,6 +8,7 @@ public interface ResponseMessage {
     String SUCCESS_CLASS_MAPPING = "모든 매핑을 새로 등록하여 코딩존 매핑을 완료";
     String SUCCESS_MAPPING_GET = "코딩존 매핑 조회 성공";
     String SUCCESS_CLASS_CREATE = "코딩존 등록 성공";
+    String SUCCESS_CLASS_DELETE = "코딩존 삭제 성공";
     String SUCCESS_CLASS_UPDATE = "코딩존 정보 수정 성공";
     String SUCCESS_POST_MAPPING = "신규 매핑 정보로 등록 성공";
     String SUCCESS_DELETE_MAPPING = "코딩존 매핑 삭제 성공 ";

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/ClassAndGroupManageController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/ClassAndGroupManageController.java
@@ -19,7 +19,7 @@ public class ClassAndGroupManageController {
 
     private final CodingZoneClassService codingZoneManagingService;
 
-    @PostMapping("") // 코딩존 수업 등록 Controller
+    @PostMapping("")
     public ResponseEntity<ResponseDto<String>> postClassAndGroup(
             @AuthenticationPrincipal String email,
             @RequestBody @Valid List<CodingZoneClassAssignRequestDto> requestBody) {
@@ -28,7 +28,7 @@ public class ClassAndGroupManageController {
         return ResponseEntity.ok(ResponseDto.success(ResponseMessage.SUCCESS_CLASS_CREATE));
     }
 
-    @PatchMapping("/{classNum}") // 특정 코딩존 수업 정보 수정 Controller
+    @PatchMapping("/{classNum}")
     public ResponseEntity<ResponseDto<String>> patchClassAndGroup(
             @AuthenticationPrincipal String email,
             @Valid @RequestBody CodingZoneClassUpdateRequestDto requestBody,
@@ -36,5 +36,13 @@ public class ClassAndGroupManageController {
 
         codingZoneManagingService.patchClassAndGroup(requestBody, classNum);
         return ResponseEntity.ok(ResponseDto.success(ResponseMessage.SUCCESS_CLASS_UPDATE));
+    }
+
+    @DeleteMapping("/{classNum}")
+    public ResponseEntity<ResponseDto<String>> deleteClass(
+            @PathVariable("classNum") Integer classNum
+    ) {
+        codingZoneManagingService.deleteClass(classNum);
+        return ResponseEntity.ok(ResponseDto.success(ResponseMessage.SUCCESS_CLASS_DELETE));
     }
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
@@ -64,15 +64,6 @@ public class EntireAdminController {
         return response;
     }
 
-    @DeleteMapping("/delete-class/{classNum}") //등록된 특정 수업 삭제 API
-    public ResponseEntity<? super DeleteClassResponseDto> deleteClass(
-        @PathVariable Integer classNum,
-        @AuthenticationPrincipal String email
-    ) {
-        ResponseEntity<? super DeleteClassResponseDto> response = codingzoneService.deleteClass(classNum, email);
-        return response;
-    }
-
     @GetMapping("/student-list") // 해당학기에 출/결한 모든 학생을 리스트로 반환 API
     public ResponseEntity<? super GetCodingZoneStudentListResponseDto> getStudentList(
         @AuthenticationPrincipal String email

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/exception/CodingZoneClassNotFoundException.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/exception/CodingZoneClassNotFoundException.java
@@ -1,0 +1,13 @@
+package com.icehufs.icebreaker.domain.codingzone.exception;
+
+import com.icehufs.icebreaker.common.ResponseCode;
+import com.icehufs.icebreaker.common.ResponseMessage;
+import com.icehufs.icebreaker.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class CodingZoneClassNotFoundException extends BusinessException {
+
+    public CodingZoneClassNotFoundException() {
+        super(ResponseCode.NOT_FOUND_CLASS, ResponseMessage.NOT_FOUND_CLASS, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/exception/ExistCodingZoneRegisterException.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/exception/ExistCodingZoneRegisterException.java
@@ -5,9 +5,9 @@ import com.icehufs.icebreaker.common.ResponseMessage;
 import com.icehufs.icebreaker.exception.BusinessException;
 import org.springframework.http.HttpStatus;
 
-public class ExistCodingZoneRegisterExcpetion extends BusinessException {
+public class ExistCodingZoneRegisterException extends BusinessException {
 
-    public ExistCodingZoneRegisterExcpetion() {
+    public ExistCodingZoneRegisterException() {
         super(ResponseCode.ALREADY_RESERVED_CLASS, ResponseMessage.ALREADY_RESERVED_CLASS, HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/exception/ExistCodingZoneRegisterExcpetion.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/exception/ExistCodingZoneRegisterExcpetion.java
@@ -1,0 +1,13 @@
+package com.icehufs.icebreaker.domain.codingzone.exception;
+
+import com.icehufs.icebreaker.common.ResponseCode;
+import com.icehufs.icebreaker.common.ResponseMessage;
+import com.icehufs.icebreaker.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class ExistCodingZoneRegisterExcpetion extends BusinessException {
+
+    public ExistCodingZoneRegisterExcpetion() {
+        super(ResponseCode.ALREADY_RESERVED_CLASS, ResponseMessage.ALREADY_RESERVED_CLASS, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/repository/CodingZoneRegisterRepository.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/repository/CodingZoneRegisterRepository.java
@@ -15,4 +15,6 @@ public interface CodingZoneRegisterRepository extends JpaRepository<CodingZoneRe
     List<CodingZoneRegister> findByUserEmail(String userEmail);
     List<CodingZoneRegister> findAllByOrderByUserStudentNumAsc();
     List<CodingZoneRegister> findAllByCodingZoneClassInOrderByUserStudentNumAsc(List<CodingZoneClass> classes);
+
+    boolean existsByCodingZoneClassClassNum(Integer classNum);
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneClassService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneClassService.java
@@ -101,15 +101,14 @@ public class CodingZoneClassService {
     @Transactional
     public void deleteClass(Integer classNum) {
 
-        CodingZoneClass codingZoneClass = codingZoneClassRepository.findByClassNum(classNum);
-        if (codingZoneClass == null) throw new CodingZoneClassNotFoundException();
+        CodingZoneClass codingZoneClass = codingZoneClassRepository.findById(classNum)
+                .orElseThrow(() -> new CodingZoneClassNotFoundException());
 
         if(codingZoneRegisterRepository.existsByCodingZoneClassClassNum(classNum)) {
             throw new ExistCodingZoneRegisterExcpetion();
-        } else {
-            codingZoneClassRepository.delete(codingZoneClass);
+        }
+        codingZoneClassRepository.delete(codingZoneClass);
         }
 
-
     }
-}
+

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneClassService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneClassService.java
@@ -5,9 +5,10 @@ import java.util.Optional;
 
 import com.icehufs.icebreaker.domain.codingzone.domain.entity.Subject;
 import com.icehufs.icebreaker.domain.codingzone.dto.request.CodingZoneClassUpdateRequestDto;
-import com.icehufs.icebreaker.domain.codingzone.exception.DuplicatedClassException;
-import com.icehufs.icebreaker.domain.codingzone.exception.AlreadyExistClassException;
-import com.icehufs.icebreaker.domain.codingzone.exception.UnmappedSubjectException;
+import com.icehufs.icebreaker.domain.codingzone.exception.*;
+import com.icehufs.icebreaker.domain.codingzone.repository.CodingZoneRegisterRepository;
+import com.icehufs.icebreaker.util.ResponseDto;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import com.icehufs.icebreaker.domain.codingzone.domain.entity.CodingZoneClass;
 import com.icehufs.icebreaker.domain.codingzone.domain.entity.GroupInf;
@@ -18,12 +19,15 @@ import com.icehufs.icebreaker.domain.codingzone.repository.GroupInfRepository;
 import com.icehufs.icebreaker.domain.codingzone.repository.SubjectRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Service
 @RequiredArgsConstructor
 public class CodingZoneClassService {
 
     private final CodingZoneClassRepository codingZoneClassRepository;
+    private final CodingZoneRegisterRepository codingZoneRegisterRepository;
     private final GroupInfRepository groupInfRepository;
     private final SubjectRepository subjectRepository;
 
@@ -92,8 +96,19 @@ public class CodingZoneClassService {
                 .orElseThrow(() -> new UnmappedSubjectException());
 
         existingClass.update(dto, subject);
+    }
 
+    @Transactional
+    public void deleteClass(Integer classNum) {
 
+        CodingZoneClass codingZoneClass = codingZoneClassRepository.findByClassNum(classNum);
+        if (codingZoneClass == null) throw new CodingZoneClassNotFoundException();
+
+        if(codingZoneRegisterRepository.existsByCodingZoneClassClassNum(classNum)) {
+            throw new ExistCodingZoneRegisterExcpetion();
+        } else {
+            codingZoneClassRepository.delete(codingZoneClass);
+        }
 
 
     }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneClassService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneClassService.java
@@ -1,14 +1,11 @@
 package com.icehufs.icebreaker.domain.codingzone.service;
 
 import java.util.List;
-import java.util.Optional;
 
 import com.icehufs.icebreaker.domain.codingzone.domain.entity.Subject;
 import com.icehufs.icebreaker.domain.codingzone.dto.request.CodingZoneClassUpdateRequestDto;
 import com.icehufs.icebreaker.domain.codingzone.exception.*;
 import com.icehufs.icebreaker.domain.codingzone.repository.CodingZoneRegisterRepository;
-import com.icehufs.icebreaker.util.ResponseDto;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import com.icehufs.icebreaker.domain.codingzone.domain.entity.CodingZoneClass;
 import com.icehufs.icebreaker.domain.codingzone.domain.entity.GroupInf;
@@ -19,8 +16,6 @@ import com.icehufs.icebreaker.domain.codingzone.repository.GroupInfRepository;
 import com.icehufs.icebreaker.domain.codingzone.repository.SubjectRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 
 @Service
 @RequiredArgsConstructor
@@ -105,10 +100,9 @@ public class CodingZoneClassService {
                 .orElseThrow(() -> new CodingZoneClassNotFoundException());
 
         if(codingZoneRegisterRepository.existsByCodingZoneClassClassNum(classNum)) {
-            throw new ExistCodingZoneRegisterExcpetion();
+            throw new ExistCodingZoneRegisterException();
         }
         codingZoneClassRepository.delete(codingZoneClass);
-        }
-
     }
 
+}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
@@ -15,7 +15,6 @@ public interface CodingZoneService {
     ResponseEntity<? super GroupInfUpdateResponseDto> uploadInf(List<GroupInfUpdateRequestDto> dto, String email);
     ResponseEntity<? super GetListOfGroupInfResponseDto> getList(String groupId, String email);
     ResponseEntity<? super GroupInfUpdateResponseDto> patchInf(List<PatchGroupInfRequestDto> dto, String email);
-    void deleteClass(Integer classNum);
     ResponseEntity<? super GetCodingZoneStudentListResponseDto> getStudentList(String email);
     String deleteAll(String email);
     ByteArrayResource generateAttendanceExcelOfGrade1() throws IOException;

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
@@ -15,7 +15,7 @@ public interface CodingZoneService {
     ResponseEntity<? super GroupInfUpdateResponseDto> uploadInf(List<GroupInfUpdateRequestDto> dto, String email);
     ResponseEntity<? super GetListOfGroupInfResponseDto> getList(String groupId, String email);
     ResponseEntity<? super GroupInfUpdateResponseDto> patchInf(List<PatchGroupInfRequestDto> dto, String email);
-    ResponseEntity<? super DeleteClassResponseDto> deleteClass(Integer classNum, String email);
+    void deleteClass(Integer classNum);
     ResponseEntity<? super GetCodingZoneStudentListResponseDto> getStudentList(String email);
     String deleteAll(String email);
     ByteArrayResource generateAttendanceExcelOfGrade1() throws IOException;

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -2,6 +2,8 @@ package com.icehufs.icebreaker.domain.codingzone.service.implement;
 
 import com.icehufs.icebreaker.common.ResponseCode;
 import com.icehufs.icebreaker.domain.codingzone.dto.response.*;
+import com.icehufs.icebreaker.domain.codingzone.exception.CodingZoneClassNotFoundException;
+import com.icehufs.icebreaker.domain.codingzone.exception.ExistCodingZoneRegisterExcpetion;
 import com.icehufs.icebreaker.domain.membership.domain.exception.UserNotFoundException;
 import com.icehufs.icebreaker.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +16,6 @@ import org.springframework.stereotype.Service;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.DayOfWeek;
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.ZoneId;
 import java.time.LocalTime;
@@ -156,24 +157,19 @@ public class CodingZoneServiceImplement implements CodingZoneService {
     }
 
     @Override
-    public ResponseEntity<? super DeleteClassResponseDto> deleteClass(Integer classNum, String email) {
-        try {
-            // 사용자 계정이 존재하는지(로그인 시간이 초과됐는지) 확인하는 코드
-            boolean existedUser = userRepository.existsByEmail(email);
-            if (!existedUser)
-                return DeleteClassResponseDto.notExistUser();
+    @Transactional
+    public void deleteClass(Integer classNum) {
 
             CodingZoneClass codingZoneClass = codingZoneClassRepository.findByClassNum(classNum);
-            if (codingZoneClass == null)
-                return DeleteClassResponseDto.noExistArticle();
+            if (codingZoneClass == null) throw new CodingZoneClassNotFoundException();
 
-            codingZoneClassRepository.delete(codingZoneClass);
+            if(codingZoneRegisterRepository.existsByCodingZoneClassClassNum(classNum)) {
+                throw new ExistCodingZoneRegisterExcpetion();
+            } else {
+                codingZoneClassRepository.delete(codingZoneClass);
+            }
 
-            return DeleteClassResponseDto.success();
-        } catch (Exception exception) {
-            exception.printStackTrace();
-            return ResponseDto.databaseError();
-        }
+
     }
 
     @Override

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -158,22 +158,6 @@ public class CodingZoneServiceImplement implements CodingZoneService {
 
     @Override
     @Transactional
-    public void deleteClass(Integer classNum) {
-
-            CodingZoneClass codingZoneClass = codingZoneClassRepository.findByClassNum(classNum);
-            if (codingZoneClass == null) throw new CodingZoneClassNotFoundException();
-
-            if(codingZoneRegisterRepository.existsByCodingZoneClassClassNum(classNum)) {
-                throw new ExistCodingZoneRegisterExcpetion();
-            } else {
-                codingZoneClassRepository.delete(codingZoneClass);
-            }
-
-
-    }
-
-    @Override
-    @Transactional
     public ResponseEntity<? super CodingZoneRegisterResponseDto> classRegist(Integer classNum, String email) {
 
         try {

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -2,8 +2,6 @@ package com.icehufs.icebreaker.domain.codingzone.service.implement;
 
 import com.icehufs.icebreaker.common.ResponseCode;
 import com.icehufs.icebreaker.domain.codingzone.dto.response.*;
-import com.icehufs.icebreaker.domain.codingzone.exception.CodingZoneClassNotFoundException;
-import com.icehufs.icebreaker.domain.codingzone.exception.ExistCodingZoneRegisterExcpetion;
 import com.icehufs.icebreaker.domain.membership.domain.exception.UserNotFoundException;
 import com.icehufs.icebreaker.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,5 +26,3 @@ spring.mail.username = ${MAIL_USERNAME}
 spring.mail.password = ${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth = true
 spring.mail.properties.mail.smtp.starttls.enable = true
-
-spring.config.import=optional:file:.env[.properties] 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -27,3 +27,4 @@ spring.mail.password = ${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth = true
 spring.mail.properties.mail.smtp.starttls.enable = true
 
+spring.config.import=optional:file:.env[.properties] 


### PR DESCRIPTION
## 📌 변경 사항
- 리펙토링 전에는, 코딩존 수업(codingZoneClass) 삭제 기능이 codingZoneRegister의 존재 여부와 상관없이 가능하도록 구현되어 있었습니다. (기존에는 JPA로 매핑 안되어 있어서 문제가 없었습니다)
- 이번 리펙토링에서는 codingZoneClass 삭제 전, 삭제하려는 해당 codingZoneClass의 classNum과 매핑관 codingZoneRegister가 존재한다면 예외처리하고 그렇지 않다면 정상 삭제되도록 비즈니스 로직을 구현하고자 합니다.

## 🔍 상세 내용
### 1️⃣비즈니스 로직 수정 내용
#### ✔️삭제하려는 codingZoneClass와 매핑된 codingZoneRegister Entity가 존재한다면, `이미 해당 수업을 예약한 학생이 있으므로, 등록 취소가 불가능한 수업입니다.` 라는 응답 메시지와 함께 예외처리 되도록 구현했습니다.
<img width="1078" height="290" alt="스크린샷 2025-08-12 002913" src="https://github.com/user-attachments/assets/89f45880-37b5-4939-8a51-7be67f9620c8" />

#### ✔️삭제하려는 codingZoneClass와 매핑된 codingZoneRegister Entity가 존재하지 않는다면, 해당 classNum을 가지는 모든 codingZoneClass Entity를 삭제하도록 구현했습니다. 
### 📍기존 성공 응답
`{
  "code": "SU",
  "message": "Success"
}`
### 📍수정된 성공 응답
<img width="572" height="271" alt="스크린샷 2025-08-12 010112" src="https://github.com/user-attachments/assets/a4a0fb8f-679a-4fb0-b80d-1c150969fee0" />

### 2️⃣controller 위치 이동 및 API path 수정
#### ✔️controller 위치 이동 : 본래, 해당 기능의 controller는 EntireAdminController에 존재했습니다. 하지만 이번 리펙토링 과정에 ClassAndGroupManageController로 옮겼습니다.
#### ✔️ API path : 본래 /api/admin/delete-class/{classNum}였지만 /api/admin/codingzones/classes/{classNum}로 수정했습니다.

 ### 3️⃣ service 위치 이동 
#### ✔️codingZoneService에서 CodingZoneClassService로 deleteClass() 메소드 이동 및 인터페이스 내 메소드 삭제를 진행했습니다.

## ✅ 체크리스트
- [X] 기능이 정상적으로 동작하는지 확인했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 없습니다!

## 📎 참고 자료 (선택)
- 없습니다!

Close #304 
