### PR TITLE
[FE-#300] 수업 등록 페이지 디자인 수정

### DIFF
--- a/frontend/src/pages/Coding-zone/CodingZoneRegist.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneRegist.js
@@ -427,7 +427,6 @@ const CodingZoneRegist = () => {
           </div>
           <div className="category-bar">
             <div className="inner-category-bar">
-              <span className="main-span2"></span>
               <button className={`reset-button`} onClick={handleResetSemester}>
                 학기 초기화
               </button>
@@ -439,7 +438,6 @@ const CodingZoneRegist = () => {
               >
                 A 조
               </button>
-              <span className="main-span2"> | </span>
               <button
                 className={`Bgroup-button ${groupId === "B" ? "active" : ""}`}
                 onClick={() => setGroupId("B")}

--- a/frontend/src/pages/css/codingzone/CodingClassRegist.css
+++ b/frontend/src/pages/css/codingzone/CodingClassRegist.css
@@ -282,7 +282,7 @@
 .class-input-box > .Assistant-input {
   min-width: 0;
   white-space: nowrap;
-  flex: 4; /* Day, Time, Assistent 입력필드의 비율 설정 */
+  flex: 3.63; /* Day, Time, Assistent 입력필드의 비율 설정 */
 }
 
 .class-input-box > .ClassName-input {
@@ -318,25 +318,26 @@
   justify-content: space-between;
 }
 .btn-5 {
-  width: 50px;
-  height: 35px;
-  line-height: 42px;
-  padding: 0;
-  border: none;
-  background: #002d56;
-  background: linear-gradient(0deg, #002d56, #002d56 100%);
-  display: flex; /* flexbox 레이아웃 사용 */
-  justify-content: center; /* 수평 중앙 정렬 */
-  align-items: center; /* 수직 중앙 정렬 */
-  color: #fff; /* 텍스트 색상 */
-  position: relative; /* 위치 조정을 위해 */
-  overflow: hidden; /* 내부 요소가 범위를 넘어서지 않게 함 */
+  display: inline-flex;
+  padding: 16px 20px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  border-radius: 10px;
+  background: #409b9d;
+  color: #fff;
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 51%; /* 10.2px */
+  letter-spacing: -0.4px;
 }
 
 .btn-5:hover {
-  color: #002d56; /* 호버 시 텍스트 색 변경 */
-  background: transparent; /* 호버 시 배경 투명 */
-  box-shadow: none; /* 박스 그림자 제거 */
+  border-radius: 10px;
+  background: rgba(64, 155, 157, 0.75);
 }
 
 .btn-5:before,
@@ -367,24 +368,20 @@
 }
 
 .btn-6 {
-  width: 25px;
-  height: 25px;
-  line-height: 42px;
-  margin-left: 10px;
-  border: none;
-  background: #002d56;
-  background: linear-gradient(0deg, #002d56, #002d56 100%);
-  display: flex; /* flexbox 레이아웃 사용 */
-  justify-content: center; /* 수평 중앙 정렬 */
-  align-items: center; /* 수직 중앙 정렬 */
-  color: #fff; /* 텍스트 색상 */
-  position: relative; /* 위치 조정을 위해 */
-  overflow: hidden; /* 내부 요소가 범위를 넘어서지 않게 함 */
+  margin: 0 0 0 5px;
+  width: px;
+  height: 35px;
+  flex-shrink: 0;
+  aspect-ratio: 1/1;
+  border: 1px solid #a8a8a8bf; /* 버튼 외곽선 색 */
+  color: #a8a8a8bf;
+  background: transparent; /* 기본 배경 투명 */
+  position: relative; /* before/after 절대 위치를 위해 필요 */
 }
 
 .btn-6:hover {
-  color: #002d56; /* 호버 시 텍스트 색 변경 */
-  background: transparent; /* 호버 시 배경 투명 */
+  color: #ffffff; /* 호버 시 텍스트 색 변경 */
+  background: #052940; /* 호버 시 배경 투명 */
   box-shadow: none; /* 박스 그림자 제거 */
 }
 
@@ -394,8 +391,6 @@
   position: absolute;
   top: 0;
   right: 0;
-  height: 2px;
-  width: 0;
   background: #002d56;
   box-shadow: -1px -1px 5px 0px #fff, 7px 7px 20px 0px #0003,
     4px 4px 5px 0px #0002;
@@ -486,13 +481,13 @@
 }
 
 .part1-element-title2 {
-  display: flex; /* 플렉스 컨테이너로 설정 */
+  display: flex;
+  width: 30rem;
+  height: 20px;
   align-items: center;
-  justify-content: center;
-  position: relative;
-  height: 90%;
-  width: 100%;
-  flex: 10; /* 40% */
+  gap: 10px;
+  flex-shrink: 0;
+  flex: 6; /* 30% */
   flex-direction: row; /* 플렉스 아이템들을 가로로 배치 */
   white-space: nowrap; /* 텍스트가 줄 바꿈되지 않도록 설정 */
 }
@@ -509,15 +504,16 @@
 }
 
 .part2-element-title2 {
-  display: flex; /* 플렉스 컨테이너로 설정 */
-  align-items: center;
+  display: flex;
+  width: 25rem;
+  height: 20px;
+  padding: 10px;
   justify-content: center;
-  position: relative;
-  height: 90%;
-  width: 100%;
-  flex: 6; /* 30% */
+  align-items: center;
+  flex-shrink: 0;
+  flex: 5; /* 30% */
   flex-direction: row; /* 플렉스 아이템들을 가로로 배치 */
-  white-space: nowrap; /* 텍스트가 줄 바꿈되지 않도록 설정 */
+  white-space: nowrap; /* 텍스트가 줄 바꿈되지 않도록 설정 */ /* 텍스트가 줄 바꿈되지 않도록 설정 */
 }
 .part2-element-title2 p {
   flex: 2; /* 각 p 태그가 공간을 균등하게 차지하도록 설정 */
@@ -526,13 +522,13 @@
 }
 
 .part3-element-title2 {
-  display: flex; /* 플렉스 컨테이너로 설정 */
+  display: flex;
+  width: 30rem;
+  height: 20px;
   align-items: center;
-  justify-content: center;
-  position: relative;
-  height: 90%;
-  width: 100%;
-  flex: 5; /* 30% */
+  gap: 15px;
+  flex-shrink: 0;
+  flex: 4; /* 30% */
   flex-direction: row; /* 플렉스 아이템들을 가로로 배치 */
   white-space: nowrap; /* 텍스트가 줄 바꿈되지 않도록 설정 */
 }
@@ -546,7 +542,7 @@
 }
 .maxPers2 {
   display: inline-block;
-  margin-right: 15% !important;
+  margin-right: 10% !important;
 }
 
 .button-area2 {

--- a/frontend/src/pages/css/codingzone/CodingClassRegist.css
+++ b/frontend/src/pages/css/codingzone/CodingClassRegist.css
@@ -108,13 +108,15 @@
 .category-bar button {
   height: 100%; /* 버튼의 높이를 컨테이너의 높이에 맞춤 */
   padding: 8px 16px; /* 내부 패딩 조정 */
-  border-color: #bfbfbf;
-  border: 1px solid #d0d5dd;
-  background-color: white;
+  border: 1px solid #efefef;
+  background-color: #efefef;
   font-family: "Inter", sans-serif;
   font-size: 13px;
   color: #bfbfbf;
   white-space: nowrap; /* 텍스트가 줄바꿈 되지 않도록 설정 */
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 18px;
 }
 
 .category-bar button:hover,
@@ -142,7 +144,7 @@
   height: 50px;
   width: 100%;
   margin: 0 0 2.5px 0;
-  gap: 8px;
+  gap: 10px;
 }
 
 .Agroup-button,

--- a/frontend/src/pages/css/codingzone/CodingClassRegist.css
+++ b/frontend/src/pages/css/codingzone/CodingClassRegist.css
@@ -325,6 +325,7 @@
   gap: 10px;
   border-radius: 10px;
   background: #409b9d;
+  border: 1px solid #409b9d;
   color: #fff;
   text-align: center;
   font-family: Pretendard;
@@ -338,33 +339,6 @@
 .btn-5:hover {
   border-radius: 10px;
   background: rgba(64, 155, 157, 0.75);
-}
-
-.btn-5:before,
-.btn-5:after {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: 0;
-  height: 2px;
-  width: 0;
-  background: #002d56;
-  box-shadow: -1px -1px 5px 0px #fff, 7px 7px 20px 0px #0003,
-    4px 4px 5px 0px #0002;
-  transition: 400ms ease all;
-}
-
-.btn-5:after {
-  right: inherit;
-  top: inherit;
-  left: 0;
-  bottom: 0;
-}
-
-.btn-5:hover:before,
-.btn-5:hover:after {
-  width: 100%; /* 호버 시 가로 길이 100%로 확장 */
-  transition: 800ms ease all;
 }
 
 .btn-6 {
@@ -414,7 +388,6 @@
   margin-top: 1%;
   margin-bottom: 1%; /* 내부 요소가 범위를 넘어서지 않게 함 */
   height: 55px;
-  margin-right: 35px;
   white-space: nowrap;
   display: flex; /* flexbox 레이아웃 사용 */
   justify-content: center; /* 수평 중앙 정렬 */
@@ -423,24 +396,29 @@
   position: relative; /* 위치 조정을 위해 */
   overflow: hidden;
 }
+
 .class-submit-button button {
-  display: flex; /* flexbox 레이아웃 사용 */
-  justify-content: center; /* 수평 중앙 정렬 */
-  align-items: center; /* 수직 중앙 정렬 */
-  position: relative; /* 위치 조정을 위해 */
-  overflow: hidden;
-  width: 50px;
-  height: 35px;
-  border-color: #002d56; /* 회색 테두리 색상 */
-  border: 1px solid #002d56;
-  background-color: white;
-  font-family: "Inter", sans-serif;
-  font-size: 15px;
-  color: #002d56; /* 텍스트 색상 설정 */
+  display: inline-flex;
+  padding: 16px 20px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  border-radius: 10px;
+  background: #052940;
+  border: 1px solid #052940;
+  color: #fff;
+  text-align: center;
+  font-family: Pretendard;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 51%; /* 10.2px */
+  letter-spacing: -0.4px;
 }
+
 .class-submit-button button:hover {
   color: white;
-  background-color: #002d56; /* 배경 색상 변경 */
+  background-color: #052940bf; /* 배경 색상 변경 */
   border-color: white; /* 테두리 색상 변경 */
 }
 
@@ -551,7 +529,8 @@
   position: relative;
   height: 8%;
   width: 100%;
-  justify-content: space-between;
+  gap: 15px;
+  justify-content: flex-end;
 }
 
 .add-button-container2 button {

--- a/frontend/src/pages/css/codingzone/CodingClassRegist.css
+++ b/frontend/src/pages/css/codingzone/CodingClassRegist.css
@@ -75,7 +75,7 @@
   flex-direction: column;
   display: flex;
   overflow: auto;
-  padding: 0 17%;
+  padding: 0 20%; /*배너에 맞추면 25.7%*/
   transform-origin: center;
   transition: transform 0.3s ease-in-out;
 }
@@ -84,15 +84,20 @@
   display: flex;
   align-items: center;
   position: relative;
-  height: 50px;
+  height: 59px;
   width: 100%;
   justify-content: space-between;
 }
 
 .reset-button {
-  margin-left: 5%;
-  border-radius: 5px;
-  transition: background-color 0.3s;
+  display: flex;
+  width: 130px;
+  height: 59px;
+  padding: 19px 16px 20px 16px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 10px;
+  background: #efefef;
 }
 
 .reset-button:hover {
@@ -118,17 +123,15 @@
   background-color: #002d56; /* 선택된 버튼과 호버 시 배경 색상 */
   border-color: #002d56; /* 선택된 버튼과 호버 시 테두리 색상 */
 }
-.main-span2 {
-  padding-right: 1%;
-  padding-left: 1%;
-}
+
 .inner-category-bar {
   display: flex;
   align-items: center;
   justify-content: flex-start; /* 내용을 오른쪽으로 정렬 */
   position: relative;
-  height: 80%;
+  height: 55px;
   width: 100%;
+  margin: 0 0 15px 0;
 }
 
 .inner-category-bar2 {
@@ -136,8 +139,32 @@
   align-items: center;
   justify-content: flex-end; /* 내용을 오른쪽으로 정렬 */
   position: relative;
-  height: 80%;
+  height: 50px;
   width: 100%;
+  margin: 0 0 2.5px 0;
+  gap: 8px;
+}
+
+.Agroup-button,
+.Bgroup-button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: #efefef; /* 기본 */
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  display: flex;
+  width: 70px;
+  padding: 19px 8px 20px 8px;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.Agroup-button.active,
+.Bgroup-button.active {
+  background-color: #052940;
+  color: #fff;
 }
 
 .separator {
@@ -245,6 +272,7 @@
   justify-content: flex-start;
   position: relative;
   width: 100%;
+  margin-top: 1%;
   margin-bottom: 1%;
 }
 
@@ -431,7 +459,13 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  height: 45px;
+  height: 59px;
+  padding: 0 1px 0 2px;
+  justify-content: center;
+  align-items: center;
+  align-self: stretch;
+  border-radius: 10px;
+  background: #052940;
 }
 
 .element-title2 {
@@ -441,6 +475,14 @@
   align-items: center;
   position: relative;
   height: 35px;
+  color: #fff;
+  text-align: center;
+  font-family: Inter;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 51%; /* 10.2px */
+  letter-spacing: -0.4px;
 }
 
 .part1-element-title2 {
@@ -455,8 +497,8 @@
   white-space: nowrap; /* 텍스트가 줄 바꿈되지 않도록 설정 */
 }
 .part1-element-title2 p {
-  flex: 1; /* 각 p 태그가 공간을 균등하게 차지하도록 설정 */
-  margin: 0 5px;
+  flex: 2; /* 각 p 태그가 공간을 균등하게 차지하도록 설정 */
+  margin: 0 4px;
   text-align: center; /* 텍스트를 가운데 정렬 */
 }
 .weekDay2,
@@ -478,7 +520,7 @@
   white-space: nowrap; /* 텍스트가 줄 바꿈되지 않도록 설정 */
 }
 .part2-element-title2 p {
-  flex: 1; /* 각 p 태그가 공간을 균등하게 차지하도록 설정 */
+  flex: 2; /* 각 p 태그가 공간을 균등하게 차지하도록 설정 */
   margin: 0 5px;
   text-align: center; /* 텍스트를 가운데 정렬 */
 }
@@ -495,7 +537,7 @@
   white-space: nowrap; /* 텍스트가 줄 바꿈되지 않도록 설정 */
 }
 .part3-element-title2 p {
-  flex: 1; /* 각 p 태그가 공간을 균등하게 차지하도록 설정 */
+  flex: 1;
   margin: 0 5px;
   text-align: center; /* 텍스트를 가운데 정렬 */
 }
@@ -581,12 +623,26 @@
   transform: scale(1.2); /* 마우스 오버 시 SVG 크기 증가 */
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1500px) {
+  .main-body-container {
+    transform: scale(1.1); /* 가로 세로로 커지게 설정 */
+    padding: 0 16%; /* padding을 줄여서 외부 공간 줄이기 */
+  }
+}
+@media (max-width: 1280px) {
+  .main-body-container {
+    transform: scale(1.1); /* 가로 세로로 커지게 설정 */
+    padding: 0 15%; /* padding을 줄여서 외부 공간 줄이기 */
+  }
+}
+
+@media (max-width: 1024px) {
   .main-body-container {
     transform: scale(1.1); /* 가로 세로로 커지게 설정 */
     padding: 0 14%; /* padding을 줄여서 외부 공간 줄이기 */
   }
 }
+
 /* 반응형 디자인을 위한 미디어 쿼리 */
 @media (max-width: 768px) {
   .main-body-container {
@@ -602,7 +658,7 @@
   }
 }
 
-@media (max-width: 510px) {
+@media (max-width: 480px) {
   .category-bar {
     flex-direction: column; /* 카테고리 바를 세로로 배열 */
     align-items: center;


### PR DESCRIPTION
## 📌 변경 사항
- 기능적으로 변경사항은 없습니다.

## 🔍 상세 내용
- 바뀌기 전 디자인
<img width="1970" height="404" alt="image" src="https://github.com/user-attachments/assets/440e4da0-4118-45f4-94a2-9be490b03e26" />

- 바뀐 후 디자인
<img width="1612" height="486" alt="image" src="https://github.com/user-attachments/assets/b047913b-c612-4110-8dec-84f185debd9a" />

1. 배너 가로 길이에 맞추려고 했지만, 답답해보여서 더 늘렸습니다.
2. 전체적으로 버튼의 크기가 커졌습니다.
3. 피그마 디자인과 유사하게 하고자 "추가" "등록" 버튼을 오른쪽으로 정렬시켰습니다.
4. 과사조교 권한 페이지라 반응형을 고려하지 않으려고 했습니다. 
하지만 앞선 주희언니 PR에서 반응형의 기준을
(1280px, 1024px, 768px, 480px)로 정한것을 확인해 최대한 맞춰보았습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.


## 📎 참고 자료 (선택)
- 완성된 전체 화면
<img width="2556" height="1523" alt="image" src="https://github.com/user-attachments/assets/6fabff81-1a96-4e44-b5b0-919012cda226" />
