### PR TITLE
[BE-#294] 학기 초기화 API 리펙토링

### DIFF
--- a/backend/build/resources/main/application.properties
+++ b/backend/build/resources/main/application.properties
@@ -27,4 +27,3 @@ spring.mail.password = ${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth = true
 spring.mail.properties.mail.smtp.starttls.enable = true
 
-spring.config.import=optional:file:.env[.properties] 

--- a/backend/src/main/java/com/icehufs/icebreaker/common/ResponseMessage.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/common/ResponseMessage.java
@@ -12,6 +12,7 @@ public interface ResponseMessage {
     String SUCCESS_CLASS_UPDATE = "코딩존 정보 수정 성공";
     String SUCCESS_POST_MAPPING = "신규 매핑 정보로 등록 성공";
     String SUCCESS_DELETE_MAPPING = "코딩존 매핑 삭제 성공 ";
+    String SUCCESS_RESET_SEMESTER = "학기 초기화 성공";
 
     // HTTP Status 400
     String BAD_REQUEST = "잘못된 입력 형식";

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
@@ -72,13 +72,6 @@ public class EntireAdminController {
         return response;
     }
 
-    @DeleteMapping("/delete-allinf") // 코딩존 관련 모든 정보 초기화(코딩존 조교 권한 박할까지) API
-    public ResponseEntity<ResponseDto<String>> deleteAll(
-        @AuthenticationPrincipal String email
-    ) {
-        return ResponseEntity.ok(ResponseDto.success(codingzoneService.deleteAll(email)));
-    }
-
     @GetMapping("/subjects/{subjectId}/assistants")
     public ResponseEntity<ResponseDto<AssistantNamesResponseDto>> getAssistantsBySubject(
             @PathVariable Long subjectId

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/SemesterMaintenanceController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/SemesterMaintenanceController.java
@@ -1,0 +1,26 @@
+package com.icehufs.icebreaker.domain.auth.controller;
+
+
+import com.icehufs.icebreaker.common.ResponseMessage;
+import com.icehufs.icebreaker.domain.codingzone.service.SemesterMaintenanceService;
+import com.icehufs.icebreaker.util.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/semester")
+@RequiredArgsConstructor
+public class SemesterMaintenanceController {
+
+    private final SemesterMaintenanceService semesterMaintenanceService;
+
+    @DeleteMapping
+    public ResponseEntity<ResponseDto<String>> deleteAll(
+    ) {
+        semesterMaintenanceService.resetSemester();
+        return ResponseEntity.ok(ResponseDto.success(ResponseMessage.SUCCESS_RESET_SEMESTER));
+    }
+}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/repostiory/AuthorityRepository.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/repostiory/AuthorityRepository.java
@@ -39,7 +39,7 @@ public interface AuthorityRepository extends JpaRepository<Authority, String> {
                a.roleAdminC3 = NULL,
                a.roleAdminC4 = NULL
     """)
-    void clearAllRoles();
+    void clearAllClassAssistantAuthority();
 
 
 

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/repostiory/AuthorityRepository.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/repostiory/AuthorityRepository.java
@@ -1,6 +1,8 @@
 package com.icehufs.icebreaker.domain.auth.repostiory;
 
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -26,4 +28,19 @@ public interface AuthorityRepository extends JpaRepository<Authority, String> {
            or a.roleAdminC4 = :role
     """)
     List<Authority> findAllByRoleValue(@Param("role") String role);
+
+
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE authority a
+           SET a.roleAdminC1 = NULL,
+               a.roleAdminC2 = NULL,
+               a.roleAdminC3 = NULL,
+               a.roleAdminC4 = NULL
+    """)
+    void clearAllRoles();
+
+
+
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
@@ -16,7 +16,6 @@ public interface CodingZoneService {
     ResponseEntity<? super GetListOfGroupInfResponseDto> getList(String groupId, String email);
     ResponseEntity<? super GroupInfUpdateResponseDto> patchInf(List<PatchGroupInfRequestDto> dto, String email);
     ResponseEntity<? super GetCodingZoneStudentListResponseDto> getStudentList(String email);
-    String deleteAll(String email);
     ByteArrayResource generateAttendanceExcelOfGrade1() throws IOException;
     ByteArrayResource generateAttendanceExcelOfGrade2() throws IOException;
 

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/SemesterMaintenanceService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/SemesterMaintenanceService.java
@@ -1,0 +1,34 @@
+package com.icehufs.icebreaker.domain.codingzone.service;
+
+import com.icehufs.icebreaker.domain.auth.repostiory.AuthorityRepository;
+import com.icehufs.icebreaker.domain.codingzone.repository.CodingZoneClassRepository;
+import com.icehufs.icebreaker.domain.codingzone.repository.CodingZoneRegisterRepository;
+import com.icehufs.icebreaker.domain.codingzone.repository.GroupInfRepository;
+import com.icehufs.icebreaker.domain.codingzone.repository.SubjectRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SemesterMaintenanceService {
+
+    private final CodingZoneClassRepository codingZoneClassRepository;
+    private final CodingZoneRegisterRepository codingZoneRegisterRepository;
+    private final GroupInfRepository groupInfRepository;
+    private final AuthorityRepository authorityRepository;
+    private final SubjectRepository subjectRepository;
+
+    @Transactional
+    public void resetSemester() {
+
+        codingZoneRegisterRepository.deleteAll();
+        groupInfRepository.deleteAll();
+        codingZoneClassRepository.deleteAll();
+        authorityRepository.clearAllRoles();
+        subjectRepository.deleteAll();
+
+    }
+}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/SemesterMaintenanceService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/SemesterMaintenanceService.java
@@ -27,7 +27,7 @@ public class SemesterMaintenanceService {
         codingZoneRegisterRepository.deleteAll();
         groupInfRepository.deleteAll();
         codingZoneClassRepository.deleteAll();
-        authorityRepository.clearAllRoles();
+        authorityRepository.clearAllClassAssistantAuthority();
         subjectRepository.deleteAll();
 
     }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -538,38 +538,6 @@ public class CodingZoneServiceImplement implements CodingZoneService {
     }
 
     @Override
-    @Transactional
-    public String deleteAll(String email) {
-        boolean existedUser = userRepository.existsByEmail(email);
-        if (!existedUser) {
-            throw new UserNotFoundException("사용자를 찾을 수 없습니다.");
-        }
-
-        // 코딩존 관련 모든 테이블 초기화
-        codingZoneRegisterRepository.deleteAll();
-        groupInfRepository.deleteAll();
-        codingZoneClassRepository.deleteAll();
-
-        // 코딩존 조교 권한 취소
-        updateAuthorities();
-        return "조교 권한을 취소하는데 성공했습니다.";
-    }
-
-    // 학기 초기화를 위한 트렌젝션 분리
-    @Transactional
-    public void updateAuthorities() {
-        List<Authority> usersC1 = authorityRepository.findByRoleAdminC1("ROLE_ADMINC1");
-        List<Authority> usersC2 = authorityRepository.findByRoleAdminC2("ROLE_ADMINC2");
-        List<Authority> usersC3 = authorityRepository.findByRoleAdminC3("ROLE_ADMINC3");
-        List<Authority> usersC4 = authorityRepository.findByRoleAdminC4("ROLE_ADMINC4");
-
-        usersC1.forEach(authority -> authority.revokeRole("ROLE_ADMINC1"));
-        usersC2.forEach(authority -> authority.revokeRole("ROLE_ADMINC2"));
-        usersC3.forEach(authority -> authority.revokeRole("ROLE_ADMINC3"));
-        usersC4.forEach(authority -> authority.revokeRole("ROLE_ADMINC4"));
-    }
-
-    @Override
     public ResponseEntity<? super GetCodingZoneAssitantListResponseDto> getAssistantList() {
         List<User> ListOfCodingZone1 = new ArrayList<>();
         List<User> ListOfCodingZone2 = new ArrayList<>();

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,3 +26,6 @@ spring.mail.username = ${MAIL_USERNAME}
 spring.mail.password = ${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth = true
 spring.mail.properties.mail.smtp.starttls.enable = true
+
+spring.config.import=optional:file:.env[.properties] 
+

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -27,5 +27,4 @@ spring.mail.password = ${MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth = true
 spring.mail.properties.mail.smtp.starttls.enable = true
 
-spring.config.import=optional:file:.env[.properties] 
 


### PR DESCRIPTION
## 📌 변경 사항
- 과사 조교 권한의 기존 기능인 "학기 초기화" API는 
1️⃣모든 codingzoneclass 데이터 초기화
2️⃣모든 codingzoneRegister 데이터 초기화
3️⃣Authority 테이블의 모든 데이터의 수업 조교 권한 박탈
➡️순서로 비즈니스 로직이 이루어져 있었습니다.
- 이번 리팩링에서는 여기에 등록된 모든 매핑 정보 삭제를 추가로 수행하도록 구현하였습니다.

## 🔍 상세 내용
### ⭐비즈니스 로직 수정 사항 
- codingzoneclass 초기화 -> codingzoneRegister 초기화 -> Authority 테이블의 ROLE_ADMINC1-4 필드 초기화 -> subject 초기화

### ⭐새로운 SemesterMaintenanceController, SemesterMaintenanceService파일 생성
- 기존 학기 초기화 기능은 EntireAdminController와 CodingZoneService에 위치해 있었습니다.
- 리팩터링 과정에서 해당 기능이 CodingZone뿐만 아니라 Authority, Subject 자원에도 접근함을 고려하여, 전용 SemesterMaintenanceController와 SemesterMaintenanceService를 신규 생성하였습니다.

### ⭐API path 수정 사항
- 기존 api path : `/api/admin/delete-allinf`
- 수정 api path : `/api/admin/semester`
- /api/admin 까지는 동일하지만, 기존 EntireAdminController에 해당 기능을 유지하지 않은 이유는 해당 컨트롤러에 아직 다른 메서드들이 존재하기 때문입니다. 추후 이 메서드들도 응답 구조를 단순화하고 공통 ResponseDto 형식으로 일관성 유지하는 리팩터링 작업을 진행할 예정입니다.

### ⭐성공 응답 수정
- 기존 응답 : 
` {
  "code": "SU",
  "message": "Success."
}`
- 수정 응답 : 
<img width="621" height="266" alt="스크린샷 2025-08-12 152121" src="https://github.com/user-attachments/assets/5a82ede9-9308-47cf-8595-806a13deac32" />

## ✅ 체크리스트
- [X] 기능이 정상적으로 동작하는지 확인했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 학기 초기화 성공 응답이 postman에 나타나는 것 확인하면서 제 개인 DB에서 codingzoneclass와 codingzoneregister, subject 테이블의 모든 데이터 값 삭제 여부와 Authority 테이블의 ROLE_ADMINC1-4 까지 값이 NULL로 초기화 됨도 확인했습니다.

## 📎 참고 자료 (선택)
- 없습니다!

close #294 