### PR TITLE
fix : findCodingZoneClassesBySubjectAndDate() 내 NPE 방지를 위한 방어적 null check 적용

### DIFF
--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/repository/GroupInfRepository.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/repository/GroupInfRepository.java
@@ -13,7 +13,7 @@ public interface GroupInfRepository extends JpaRepository<GroupInf, Integer> {
 
     List<GroupInf> findByGroupId(String groupId);
 
-    GroupInf findByClassNum(int classNum);
+    Optional<GroupInf> findByClassNum(Integer classNum);
 
     void deleteByGroupId(String groupId);
 

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -375,7 +375,8 @@ public class CodingZoneServiceImplement implements CodingZoneService {
             CodingZoneClassInfoResponseDto dto = new CodingZoneClassInfoResponseDto(
                     codingZoneClass.getClassTime(),
                     codingZoneClass.getAssistantName(),
-                    groupInfRepository.findByClassNum(codingZoneClass.getClassNum()).orElseThrow(GroupInfNotFoundException::new).getGroupId(),
+                    groupInfRepository.findByClassNum(codingZoneClass.getClassNum()).orElseThrow(GroupInfNotFoundException::new)
+                            .getGroupId(),
                     codingZoneClass.calculateClassStatus(date),
                     codingZoneClass.getClassNum());
 

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -14,6 +14,7 @@ import com.icehufs.icebreaker.domain.codingzone.dto.response.SubjectMappingInfoR
 import com.icehufs.icebreaker.domain.codingzone.dto.response.AssistantNamesResponseDto;
 import com.icehufs.icebreaker.domain.codingzone.dto.response.CodingZoneClassInfoResponseDto;
 
+import com.icehufs.icebreaker.domain.codingzone.exception.GroupInfNotFoundException;
 import com.icehufs.icebreaker.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -25,8 +26,6 @@ import java.time.ZoneId;
 import java.time.LocalTime;
 import java.time.LocalDate;
 import java.util.List;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -118,7 +117,7 @@ public class CodingZoneServiceImplement implements CodingZoneService {
 
             // 각 수업을 수정
             for (PatchGroupInfRequestDto dtos : dto) {
-                GroupInf existingEntity = groupInfRepository.findByClassNum(dtos.getClassNum());
+                GroupInf existingEntity = groupInfRepository.findByClassNum(dtos.getClassNum()).orElseThrow(GroupInfNotFoundException::new);
                 if (existingEntity != null) {
                     existingEntity.setAssistantName(dtos.getAssistantName());
                     existingEntity.setClassTime(dtos.getClassTime());
@@ -378,7 +377,7 @@ public class CodingZoneServiceImplement implements CodingZoneService {
             CodingZoneClassInfoResponseDto dto = new CodingZoneClassInfoResponseDto(
                     codingZoneClass.getClassTime(),
                     codingZoneClass.getAssistantName(),
-                    groupInfRepository.findByClassNum(codingZoneClass.getClassNum()).getGroupId(),
+                    groupInfRepository.findByClassNum(codingZoneClass.getClassNum()).orElseThrow(GroupInfNotFoundException::new).getGroupId(),
                     codingZoneClass.calculateClassStatus(date),
                     codingZoneClass.getClassNum());
 


### PR DESCRIPTION
## 📌 변경 사항
- findCodingZoneClassesBySubjectAndDate() 메소드에 null-safety 로직 추가
- NPE 발생 가능성을 차단하기 위한 null check 후 예외처리 추

## 🔍 상세 내용
-특정 조건에서 GroupInf 또는 관련 엔티티가 조회되지 않을 경우 null이 반환되어 getGroupId() 호출 시 NPE가 발생할 수 있던 문제를 확인
- 이를 방지하기 위해 null-check 로직을 추가하여 안전하게 예외를 처리하도록 수정
- 필요 시 GroupInfNotFoundException을 발생시켜 프론트엔드가 예측 가능한 에러 응답을 받을 수 있도록 개선

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 없습니다.

## 📎 참고 자료 (선택)
- 없습니다.
