### PR TITLE
[FE-#346] 코딩존 조교 정보 반환 API 수정 

### DIFF
--- a/frontend/src/features/api/Admin/Codingzone/InquiryApi.js
+++ b/frontend/src/features/api/Admin/Codingzone/InquiryApi.js
@@ -1,12 +1,12 @@
 import axios from 'axios';
 
 const DOMAIN = process.env.REACT_APP_API_DOMAIN; 
-const GET_CZ_ASSITANT = () => `${DOMAIN}/api/v1/coding-zone/assistant-list`;
+const GET_CZ_ASSITANT = () => `${DOMAIN}/api/v1/coding-zone/assistants`;
 //21. 코딩존 조교 정보 반환 API
-export const getczassitantRequest =  async () => {
+export const getCzAssistantsRequest =  async () => {
     try {
-        const response = await axios.get(GET_CZ_ASSITANT());
-        return response.data;
+        const { data } = await axios.get(GET_CZ_ASSISTANTS());
++        return data; // { code, message, data: [...] }
     } catch (error) {
         if (!error.response || !error.response.data) return null;
         return error.response.data;

--- a/frontend/src/pages/Coding-zone/InquiryModal.js
+++ b/frontend/src/pages/Coding-zone/InquiryModal.js
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from '../css/codingzone/InquiryModal.module.css';
-import { getczassitantRequest } from '../../features/api/Admin/Codingzone/InquiryApi';
+import { getCzAssistantsRequest } from '../../features/api/Admin/Codingzone/InquiryApi';
 
 const InquiryModal = ({ isOpen, onClose }) => {
-    const [assistants, setAssistants] = useState({ zone1: [], zone2: [] });
-    const navigate = useNavigate();
+    const navigate = useNavigate(); 
+    const [subjects, setSubjects] = useState([]); // [{subjectName, assistants:[{email,studentNum,name}]}]
+    const [status, setStatus] = useState('idle'); // idle | loading | success | empty | error
+    const [errorMsg, setErrorMsg] = useState('');
 
     useEffect(() => {
         if (isOpen) {
@@ -14,14 +16,29 @@ const InquiryModal = ({ isOpen, onClose }) => {
     }, [isOpen]);
 
     const fetchAssistants = async () => {
-        const response = await getczassitantRequest();
-        if (response && response.code === "SU") {
-            setAssistants({
-                zone1: response.listOfCodingZone1,
-                zone2: response.listOfCodingZone2
-            });
-        }else {
-            console.error(response.message);
+        setStatus('loading');
+        setErrorMsg('');
+        const response = await getCzAssistantsRequest();
+        if (!response) {
+          setStatus('error');
+          setErrorMsg('네트워크 오류가 발생했습니다.');
+          return;
+        }
+        if (response.code === 'SU' && Array.isArray(response.data)) {
+          if (response.data.length === 0) {
+            setSubjects([]);
+            setStatus('empty');
+          } else {
+            setSubjects(response.data);
+            setStatus('success');
+          }
+        } else if (response.code === 'NO_ANY_ASSISTANTS') {
+          setSubjects([]);
+          setStatus('empty');
+          setErrorMsg('조교가 등록된 과목이 아직 없습니다.');
+        } else {
+          setStatus('error');
+          setErrorMsg(response.message || '조회 중 오류가 발생했습니다.');
         }
     };
 
@@ -37,25 +54,25 @@ const InquiryModal = ({ isOpen, onClose }) => {
                     <strong>이메일:</strong> ice@hufs.ac.kr<br />
                     <strong>연락처:</strong> 031-330-4255
                 </div>
-                <div className={styles.title}><strong>코딩존 조교</strong></div>
+                  <div className={styles.title}><strong>코딩존 조교</strong></div>
                 <div className={styles.modalBody}>
-    <strong>코딩존 1</strong>
-    <ul style={{ listStyleType: 'none' }}> 
-        {assistants.zone1.map((assistant, index) => (
-            <li key={index}>
-                {assistant.name} ({assistant.email})
-            </li>
-        ))}
-    </ul>
-    <strong>코딩존 2</strong>
-    <ul style={{ listStyleType: 'none' }}>
-        {assistants.zone2.map((assistant, index) => (
-            <li key={index}>
-                {assistant.name} ({assistant.email})
-            </li>
-        ))}
-    </ul>
-</div>
+                  {status === 'loading' && <div>불러오는 중...</div>}
+                  {status === 'empty' && <div>{errorMsg || '표시할 과목이 없습니다.'}</div>}
+                  {status === 'error' && <div style={{ color: '#d33' }}>{errorMsg}</div>}
+                  {status === 'success' && subjects.map((s, i) => (
+                    <div key={i} style={{ marginBottom: 16 }}>
+                      <strong>{s.subjectName}</strong>
+                      <ul style={{ listStyleType: 'none', paddingLeft: 0, marginTop: 8 }}>
+                        {s.assistants.map((a, idx) => (
+                          <li key={idx}>
+                            {a.name} ({a.email})
+                            {/* 필요 시 학번 노출:  - {a.studentNum} */}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## 📌 변경 사항
- 코딩존 조교 조회 API 엔드포인트를 /api/v1/coding-zone/assistants로 교체
- API 모듈 함수명 및 네이밍 정리: getczassitantRequest → getCzAssistantsRequest
- InquiryModal UI를 “코딩존 1/2” 구분 → 과목명(볼드) + 조교 목록(이름·이메일) 구조로 개편
- 상태 관리 추가: loading / success / empty / error 및 사용자 메시지 노출
- 예외 코드 처리: NO_ANY_ASSISTANTS, DBE 대응

## 🔍 상세 내용
**데이터 모델 변경**

- 상태: subjects: Array<{ subjectName: string; assistants: Array<{ email; studentNum; name }> }>

- 성공(code === 'SU') 시 리스트 렌더, 빈 배열이면 empty 처리

**요청/응답 처리** 

- GET /api/v1/coding-zone/assistants 호출

- 네트워크 실패 → error + “네트워크 오류” 안내

- NO_ANY_ASSISTANTS → empty + “조교가 등록된 과목이 아직 없습니다.” 안내

- DBE 및 기타 → error + 서버 메시지 노출

**렌더링 로직**

- 과목 단위 섹션 <strong>{subjectName}</strong> 아래

- assistants.map(a => <li>{a.name} ({a.email})</li>)

- 필요 시 학번은 주석 해제로 노출 가능(a.studentNum)

**UI/UX**

- 로딩 시 “불러오는 중…”, 빈 상태/에러 상태 명확히 분기

- 불필요한 “코딩존 1/2” 텍스트/스타일 제거

- 리스트는 ul + li로 접근성 유지, 인라인 스타일 최소화

## ✅ 체크리스트
- [X] 기능이 정상적으로 동작하는지 확인했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 없음.

## 📎 참고 자료 (선택)
<img width="1111" height="745" alt="스크린샷 2025-08-18 오전 12 35 26" src="https://github.com/user-attachments/assets/7355c490-c1d8-492a-80c1-485dc07a5470" />
