### PR TITLE
[FE-#388] 헤더 및 바디 부분 수정

### DIFF
--- a/frontend/src/pages/Coding-zone/CodingZoneMain.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneMain.js
@@ -874,16 +874,14 @@ const CodingMain = () => {
               </div>
             )}
 
-            {/* 과목 버튼(칩)이 아예 없을 때만 안내 이미지 표시 */}
+            {/* 과목 버튼이 아예 없을 때만 안내 이미지 표시 */}
             {publicSubjects.length === 0 && (
-              <div className="panel-block panel-gray">
-                <img
-                  src="/Codingzone-noregist.png"
-                  alt="예약 안내 이미지"
-                  className="czp-guide-image"
-                  style={{ width: "1100px", height: "auto" }}
-                />
-              </div>
+              <img
+                src="/Codingzone-noregist.png"
+                alt="예약 안내 이미지"
+                className="czp-guide-image"
+                style={{ width: "1000px", height: "auto" }}
+              />
             )}
 
             {/* ② 로딩 중: 회색 패널로 로딩 표시 (표 헤더 깜빡임 방지) */}

--- a/frontend/src/pages/Coding-zone/CodingZoneMain.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneMain.js
@@ -865,12 +865,24 @@ const CodingMain = () => {
           ))}
         {!isAdmin && (
           <>
-            {/* ① 과목 미선택: 기존 회색 패널 재사용 */}
-            {!selectedSubjectIdPub && (
+            {/* ① 과목칩이 있을 때: 선택 전이면 문구만 노출 */}
+            {publicSubjects.length > 0 && !selectedSubjectIdPub && (
               <div className="panel-block panel-gray">
                 <div className="panel-empty">
                   예약하고자 하는 코딩존을 선택해주세요.
                 </div>
+              </div>
+            )}
+
+            {/* 과목 버튼(칩)이 아예 없을 때만 안내 이미지 표시 */}
+            {publicSubjects.length === 0 && (
+              <div className="panel-block panel-gray">
+                <img
+                  src="/Codingzone-noregist.png"
+                  alt="예약 안내 이미지"
+                  className="czp-guide-image"
+                  style={{ width: "1100px", height: "auto" }}
+                />
               </div>
             )}
 

--- a/frontend/src/pages/css/codingzone/CodingClassRegist.css
+++ b/frontend/src/pages/css/codingzone/CodingClassRegist.css
@@ -598,20 +598,17 @@
 
 @media (max-width: 1500px) {
   .main-body-container {
-    transform: scale(1.1); /* 가로 세로로 커지게 설정 */
     padding: 0 16%; /* padding을 줄여서 외부 공간 줄이기 */
   }
 }
 @media (max-width: 1280px) {
   .main-body-container {
-    transform: scale(1.1); /* 가로 세로로 커지게 설정 */
     padding: 0 15%; /* padding을 줄여서 외부 공간 줄이기 */
   }
 }
 
 @media (max-width: 1024px) {
   .main-body-container {
-    transform: scale(1.1); /* 가로 세로로 커지게 설정 */
     padding: 0 14%; /* padding을 줄여서 외부 공간 줄이기 */
   }
 }

--- a/frontend/src/pages/css/codingzone/codingzone-main.css
+++ b/frontend/src/pages/css/codingzone/codingzone-main.css
@@ -88,8 +88,7 @@ body {
   display: flex;
   justify-content: center; /* 중앙 정렬 */
   align-items: center;
-  gap: 0; /* 같이 있던 요소 분리했으니 gap 제거해도 OK */
-  margin-top: 0; /* -20px로 올라가 있으면 중앙 정렬이 어긋남 -> 0 권장 */
+  margin-top: -25px;
 }
 
 .cz-category-date {
@@ -274,7 +273,6 @@ body {
   position: absolute;
   top: -9999px;
 }
-
 
 .no-classes-image.visible {
   opacity: 1;

--- a/frontend/src/shared/ui/boardbar/CodingZoneBoardbar.css
+++ b/frontend/src/shared/ui/boardbar/CodingZoneBoardbar.css
@@ -2,7 +2,7 @@
 .cza_button_container {
   display: flex; /* 기본값 : row */
   width: 100%;
-  margin: 1.7rem 0 1.0625rem 0;
+  margin: 1.3rem 0 1.0625rem 0;
   justify-content: center;
   align-items: center;
   gap: 1.875rem;

--- a/frontend/src/shared/ui/navigation/CodingZoneNavigation.css
+++ b/frontend/src/shared/ui/navigation/CodingZoneNavigation.css
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 19rem;
+  gap: 10rem; /* 기존은 19rem */
 }
 .cz-nav-btn {
   flex: 0 0 auto !important; /* flex:1로 늘어나는 것 방지 */

--- a/frontend/src/widgets/layout/Header/Navbar.css
+++ b/frontend/src/widgets/layout/Header/Navbar.css
@@ -9,7 +9,7 @@
   width: 100%;
   max-width: 1600px;
   margin: 0 auto;
-  padding: 70px 0 13px 11px;
+  padding: 20px 0 13px 11px;
   display: flex;
   justify-content: space-between;
   border-bottom: 1px solid #052940;
@@ -54,7 +54,7 @@ nav.navbar .nav-link[data-open="true"] {
     margin: 0 0 25px 0;
   }
   .header-container {
-    padding: 89px 0 12px 12px;
+    padding: 20px 0 12px 12px;
   }
   .header-container img {
     width: 165px;
@@ -71,7 +71,7 @@ nav.navbar .nav-link[data-open="true"] {
     margin: 0 0 24px 0;
   }
   .header-container {
-    padding: 70px 0 12px 13px;
+    padding: 20px 0 12px 13px;
   }
   .header-container img {
     width: 165px;
@@ -88,7 +88,7 @@ nav.navbar .nav-link[data-open="true"] {
     margin: 0 0 19px 0;
   }
   .header-container {
-    padding: 48px 0 8px 14px;
+    padding: 15px 0 8px 14px;
   }
   .header-container img {
     width: 125px;
@@ -105,7 +105,7 @@ nav.navbar .nav-link[data-open="true"] {
     margin: 0 0 14px 0;
   }
   .header-container {
-    padding: 28px 0 7px 15px;
+    padding: 10px 0 7px 15px;
   }
   .header-container img {
     width: 92px;


### PR DESCRIPTION
## 📌 변경 사항
- QA때 나온 디자인적 요소 수정

## 🔍 상세 내용
1️⃣ 헤더 위 여백이 수정
여백이 너무 많다는 피드백을 받아 여백을 줄였습니다.
<img width="1401" height="812" alt="image" src="https://github.com/user-attachments/assets/56b1dbdd-52ae-441b-909e-b4f360042293" />

2️⃣ 보드바 크기 수정
너비가 1500px 이하일시 수업등록, 코딩존 설정 페이지에서 보드바 커지는 문제가 발생하여 
문제 코드를 삭제했습니다.
-> 푸터 겹침 문제도 해결됨

3️⃣ 캘린더, 보드바 위 여백
캘린더와 보드바 위 여백을 줄였습니다.

4️⃣ 네비게이션 바 gap
gap을 줄였으면 좋겠다는 피드백을 받아 여러 gap으로 슬랙에 투표를 올렸는데 현 시점 제일 득표수가 많은 10rem으로 수정했습니다.
-> 후에 투표 결과가 바뀌면 다시 푸시 하겠습니다.

5️⃣ 부엉이 사진
원래는 과목설정이 끝나기 전에 예약하고자 하는 코딩존을 선택해주세요. 라는 문구가 떴었는데 부엉이 사진으로 대체
<img width="1889" height="937" alt="image" src="https://github.com/user-attachments/assets/93ddd00c-12b1-4d86-b49f-3bd721946838" />

과목 버튼이 생기면 원래의 예약하고자 하는 코딩존을 선택해주세요. 문구가 뜸


## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
