### PR TITLE
[FE-#409] 학생권한 코딩존 예약 페이지 반응형 구현

### DIFF
--- a/frontend/src/pages/css/codingzone/codingzone-main.css
+++ b/frontend/src/pages/css/codingzone/codingzone-main.css
@@ -615,7 +615,9 @@ body {
   }
 
   .cz-count-container {
-    transform: scale(0.75);
+    transform: scale(0.7);
+    margin-bottom: -60px;
+    margin-right: 90px;
   }
 }
 

--- a/frontend/src/pages/css/codingzone/codingzone-main.css
+++ b/frontend/src/pages/css/codingzone/codingzone-main.css
@@ -411,7 +411,7 @@ body {
 } /* 시간 */
 .czp-table th:nth-child(3),
 .czp-table td:nth-child(3) {
-  width: 1fr;
+  width: 250px;
 } /* 수업명(유동) */
 .czp-table th:nth-child(4),
 .czp-table td:nth-child(4) {
@@ -586,6 +586,33 @@ body {
   .czp-subject-bar .czp-chip {
     transform: scale(0.9);
   }
+
+  .czp-weekbar {
+    margin: 0 14px 4px 14px; /* 기존 20px → 4px로 축소 (원하면 0으로) */
+    padding-bottom: 0;
+  }
+
+  /* 표 래퍼 쪽 기본 여백/UA margin 차단 */
+  .czp-table-wrap,
+  .czp-table-shell,
+  .czp-table-scroll,
+  .czp-table {
+    margin: 0;
+    padding: 0;
+  }
+
+  /* scale로 줄일 때 위쪽 기준으로 줄어들게(시각적 간격 최소화) */
+  .czp-weekbar,
+  .czp-table {
+    transform-origin: top center;
+  }
+
+  .czp-weekbar,
+  .czp-table {
+    transform: scale(0.75);
+    justify-self: center;
+    white-space: nowrap;
+  }
 }
 
 @media (max-width: 768px) {
@@ -625,8 +652,34 @@ body {
   }
 
   .czp-subject-bar {
-    transform: scale(0.8);
+    transform: scale(0.7);
     gap: 10px;
+  }
+
+  .czp-weekbar {
+    gap: 35px;
+    white-space: nowrap;
+    transform: scale(0.8);
+  }
+  .czp-table {
+    flex-wrap: nowrap;
+    white-space: nowrap;
+    transform: scale(0.6);
+    justify-self: center;
+  }
+}
+
+@media (max-width: 600px) {
+  .czp-weekbar {
+    gap: 35px;
+    white-space: nowrap;
+    transform: scale(0.7);
+  }
+  .czp-table {
+    flex-wrap: nowrap;
+    white-space: nowrap;
+    transform: scale(0.52);
+    justify-self: center;
   }
 }
 
@@ -678,6 +731,17 @@ body {
   .czp-subject-bar {
     transform: scale(0.7);
   }
+
+  .czp-weekbar {
+    gap: 40px;
+    transform: scale(0.55);
+  }
+  .czp-table {
+    flex-wrap: nowrap;
+    white-space: nowrap;
+    transform: scale(0.45);
+    justify-self: center;
+  }
 }
 
 @media (max-width: 395px) {
@@ -685,5 +749,25 @@ body {
   .codingzone-title p,
   .codingzone-date button {
     font-size: 12px;
+  }
+  .czp-table-wrap {
+    margin: 0;
+    padding: 0;
+  }
+
+  .czp-subject-bar {
+    transform: scale(0.5);
+  }
+
+  .czp-weekbar {
+    gap: 35px;
+    transform: scale(0.55);
+    margin-bottom: 0px;
+  }
+  .czp-table {
+    flex-wrap: nowrap;
+    white-space: nowrap;
+    transform: scale(0.35);
+    justify-self: center;
   }
 }

--- a/frontend/src/pages/css/codingzone/codingzone-main.css
+++ b/frontend/src/pages/css/codingzone/codingzone-main.css
@@ -252,7 +252,7 @@ body {
   cursor: pointer;
   text-decoration: none;
   color: inherit;
-  margin-bottom: -70px;
+
   margin-top: 0px;
   margin-left: auto;
   font-size: 12px;
@@ -613,6 +613,10 @@ body {
     justify-self: center;
     white-space: nowrap;
   }
+
+  .cz-count-container {
+    transform: scale(0.75);
+  }
 }
 
 @media (max-width: 768px) {
@@ -681,6 +685,11 @@ body {
     transform: scale(0.52);
     justify-self: center;
   }
+  .cz-count-container {
+    transform: scale(0.6);
+    margin-bottom: -55px;
+    margin-right: 40%;
+  }
 }
 
 @media (max-width: 480px) {
@@ -741,6 +750,12 @@ body {
     white-space: nowrap;
     transform: scale(0.45);
     justify-self: center;
+  }
+
+  .cz-count-container {
+    transform: scale(0.6);
+    margin-bottom: -55px;
+    margin-right: 39%;
   }
 }
 


### PR DESCRIPTION
## 📌 변경 사항
-  코딩존 예약 페이지에 반응형 구현

## 🔍 상세 내용
- 1280, 1024, 768, 480px 기준 미디어 쿼리 구현

1️⃣ 480px 미만
<img width="629" height="848" alt="image" src="https://github.com/user-attachments/assets/c1189dcc-6a90-4786-a6ba-4902b89d3fa9" />
출석률을 과목명과 요일바 사이에 위치

- 요일바와 표, 출석율 반응형 구현

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
