### PR TITLE
[FE-#422] 문의하기 모달창 우선순위 조정

### DIFF
--- a/frontend/src/pages/css/codingzone/InquiryModal.module.css
+++ b/frontend/src/pages/css/codingzone/InquiryModal.module.css
@@ -2,7 +2,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 1050;
+    z-index: 12000;
     width: 100vw;
     height: 100vh;
     background-color: rgba(202, 202, 202, 0.6);
@@ -27,7 +27,7 @@
     box-sizing: border-box;
     position: relative;
     pointer-events: auto;
-    z-index: 1051;
+    z-index: 12001;
     max-height: 80vh;
     overflow-y: auto;
     font-family: sans-serif;  

--- a/frontend/src/shared/ui/navigation/CodingZoneNavigation.css
+++ b/frontend/src/shared/ui/navigation/CodingZoneNavigation.css
@@ -33,7 +33,7 @@
 }
 
 /* 반응형 */
-/* ≤ 1280px 반응형 */
+/* ≤ 1280px */
 @media (max-width: 1280px) {
   .select-container {
     gap: 12rem;
@@ -45,41 +45,47 @@
   }
 }
 
-/* ≤ 1024px 반응형 */
+/* ≤ 1024px */
 @media (max-width: 1024px) {
   .select-container {
-    gap: 9.5rem;
-    transform: scale(0.95);
+    gap: 8rem;         /* 간격 축소로 대체 */
+    padding: 0 1rem;   /* 좌우 패딩 */
+    /* transform: scale(0.95);  제거 */
   }
   .cz-nav-btn.btn-codingzone,
   .cz-nav-btn.btn-attendence,
   .cz-nav-btn.btn-inquiry {
-    font-size: 0.85rem;
+    font-size: 0.85rem;     /* 텍스트 크기로 축소 효과 */
+    padding: 0.7em 1.5em;   /* 버튼 패딩 소폭 축소 */
   }
 }
 
-/* ≤ 768px 반응형 */
+/* ≤ 768px */
 @media (max-width: 768px) {
   .select-container {
-    gap: 8rem;
-    transform: scale(0.9);
+    gap: 6rem;
+    padding: 0 0.75rem;
+    /* transform: scale(0.9);  제거 */
   }
   .cz-nav-btn.btn-codingzone,
   .cz-nav-btn.btn-attendence,
   .cz-nav-btn.btn-inquiry {
     font-size: 0.8rem;
+    padding: 0.65em 1.35em;
   }
 }
 
-/* ≤ 480px 반응형 */
+/* ≤ 480px */
 @media (max-width: 480px) {
   .select-container {
-    gap: 4rem;
-    transform: scale(0.9);
+    gap: 3rem;
+    padding: 0 0.5rem;
+    /* transform: scale(0.9);  제거 */
   }
   .cz-nav-btn.btn-codingzone,
   .cz-nav-btn.btn-attendence,
   .cz-nav-btn.btn-inquiry {
-    font-size: 0.65rem;
+    font-size: 0.7rem;
+    padding: 0.55em 1.1em;
   }
 }


### PR DESCRIPTION
## 📌 변경 사항
- 모달 레이어 우선순위 상향: .root → z-index: 12000, .modalContainer → z-index: 12001로 조정

- 반응형 구간(≤1024px/768px/480px)에서 .select-container의 transform: scale(...) 제거
→ gap/padding/버튼 padding 축소로 대체

## 🔍 상세 내용
- 문제 원인: 작은 화면에서 .select-container에 적용된 transform: scale(...)가 새 스태킹 컨텍스트를 만들어, 모달(position: fixed; z-index: 12001)이 다른 전역 요소와 올바르게 비교되지 못하고 뒤로 밀림.

해결 방법

- 모달 오버레이/컨테이너 z-index 상향으로 기본 우선순위 확보

- 미디어쿼리 내 transform 제거로 스태킹 컨텍스트 원천 차단

- media (max-width: 1024px/768px/480px)에서 transform: scale(...) 삭제. 대신 gap/padding/버튼 padding을 축소해 시각적 크기만 조정

영향 범위

- 네비게이션 버튼 간 간격과 버튼 내부 여백이 소폭 변화(시각적 차이 최소)

- 모달은 모든 뷰포트에서 항상 최상단에 안정적으로 노출

## ✅ 체크리스트
- [X] 기능이 정상적으로 동작하는지 확인했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
없음.

## 📎 참고 자료 (선택)
<img width="1502" height="1478" alt="image" src="https://github.com/user-attachments/assets/602d0461-6841-4bca-9290-dc7cbb156aad" />

